### PR TITLE
Remove Develop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "rust"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 authors = ["Tyler St. Onge <tyler@stonge.dev>"]

--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ Hand-written implementations in Rust for personal reference.
       - [Dynamic](/src/structure/collection/linear/array/dynamic.rs)
     - [List](/src/structure/collection/linear/list.rs)
       - [Singly Linked](/src/structure/collection/linear/list/singly.rs)
+      - [Doubly Linked](/src/structure/collection/linear/list/doubly.rs)


### PR DESCRIPTION
I had been using git flow, but that project has since been abandoned. Moreover, since this repository doesn't have real 'releases', the distinction between develop and main is purely semantic. With GitHub desiring all topic branches fork from the main branch and all pull requests merge into the main branch, constantly specifying develop is annoying. Having only one long living branch would also promote all recent changes to on lookers which is okay because this exists as a reference and nothing should rely upon expected behavior.