### PR TITLE
94 clean up heapsort implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "rust"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 
 authors = ["Tyler St. Onge <tyler@stonge.dev>"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Hand-written implementations in Rust for personal reference.
       - [Bottom Up](/src/algorithm/sort/comparison/merge.rs#:~:text=bottom_up)
       - [In-Place](/src/algorithm/sort/comparison/merge.rs#:~:text=in_place)
     - [Heap](/src/algorithm/sort/comparison/heap.rs)
+      - [Top Down](/src/algorithm/sort/comparison/heap.rs#:~:text=top_down)
+      - [Bottom Up](/src/algorithm/sort/comparison/heap.rs#:~:text=bottom_up)
+      - [Inline](/src/algorithm/sort/comparison/heap.rs#:~:text=inline)
 
 ## Data Structures
 

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -26,7 +26,7 @@
 /// ```
 pub fn bottom_up<T: Ord>(elements: &mut [T]) {
     // Order `elements` in max-heap order, hence `elements[0]` is the greatest.
-    max_heapify::bottom_up(elements);
+    construct_heap::bottom_up(elements);
 
     for end in (0..elements.len()).rev() {
         // Place the greatest element not yet sorted into sorted order.
@@ -109,7 +109,7 @@ pub fn inline<T: Ord>(elements: &mut [T]) {
 /// ```
 pub fn top_down<T: Ord>(elements: &mut [T]) {
     // Order `elements` in max-heap order, hence `elements[0]` is the greatest.
-    max_heapify::top_down(elements);
+    construct_heap::top_down(elements);
 
     for end in (0..elements.len()).rev() {
         // Place the greatest element not yet sorted into sorted order.
@@ -124,6 +124,7 @@ pub fn top_down<T: Ord>(elements: &mut [T]) {
 ///
 /// # Performance
 /// This method takes O(1) time and consumes O(1) memory.
+#[inline]
 fn left_child(index: usize) -> usize {
     2 * index + 1
 }
@@ -132,6 +133,7 @@ fn left_child(index: usize) -> usize {
 ///
 /// # Performance
 /// This method takes O(1) time and consumes O(1) memory.
+#[inline]
 fn right_child(index: usize) -> usize {
     2 * index + 2
 }
@@ -140,6 +142,7 @@ fn right_child(index: usize) -> usize {
 ///
 /// # Performance
 /// This method takes O(1) time and consumes O(1) memory.
+#[inline]
 fn parent(index: usize) -> usize {
     (index - 1) / 2
 }
@@ -248,8 +251,8 @@ mod sift_down {
     }
 }
 
-/// Construct a binary max-heap.
-mod max_heapify {
+/// Construct a binary max-heap (also known as heapify).
+mod construct_heap {
     use super::parent;
     use super::sift_down;
     use super::sift_up;

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -18,6 +18,7 @@ fn parent(index: usize) -> usize {
     (index - 1) / 2
 }
 
+/// Move a misplaced node down a heap into the correct level.
 mod sift_down {
     use super::*;
 

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -1,5 +1,8 @@
 //! Implementations of [Heap Sort](https://en.wikipedia.org/wiki/Heapsort).
 
+#![allow(clippy::arithmetic_side_effects)]
+#![allow(clippy::indexing_slicing)]
+
 /// Index of the left child of the node at `index` in a binary heap.
 fn left_child(index: usize) -> usize {
     2 * index + 1

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -156,15 +156,14 @@ mod max_heapify {
 /// assert_eq!(elements, [0, 1, 2, 3, 4, 5]);
 /// ```
 pub fn bottom_up<T: Ord>(elements: &mut [T]) {
+    // Order `elements` in max-heap order, hence `elements[0]` is the greatest.
     max_heapify::bottom_up(elements);
 
     for end in (0..elements.len()).rev() {
-        // max-heap implies the root node is the greatest in the collection,
-        // pop it from the max-heap by swapping it with the last element.
+        // Place the greatest element not yet sorted into sorted order.
         elements.swap(0, end);
 
-        // push the new root into the shrunk max-heap excluding sorted element.
-        // sift_down(&mut max_heap[..end]);
+        // Sift down the leaf into the max-heap (excluding sorted elements).
         sift_down::bottom_up(&mut elements[..end]);
     }
 }

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -110,20 +110,22 @@ mod max_heapify {
     /// # Performance
     /// This method takes O(N log N) time and consumes O(1) memory.
     pub(super) fn bottom_up<T: Ord>(elements: &mut [T]) {
-        if elements.len() > 1 {
-            // `last` is the parent of the last element hence it is the greatest
-            // index of a node in the heap which has children. Since elements
-            // within `slice[first..]` are leaves to some subtree rooted by an
-            // index in `slice[..=first]`, therefore they can be skipped because
-            // [`sift_down`] orders them when the index of their parent is reached.
-            let last = parent(elements.len() - 1);
+        if elements.len() <= 1 {
+            return;
+        }
 
-            // By going in reverse, since children of `node` will either be leaves
-            // or subtrees already heap ordered, therefore sift it down until the
-            // tree rooted at `node` is itself heap ordered.
-            for node in (0..=last).rev() {
-                sift_down::top_down(&mut elements[node..]);
-            }
+        // `last` is the parent of the last element hence it is the greatest
+        // index of a node in the heap which has children. Since elements
+        // within `slice[first..]` are leaves to some subtree rooted by an
+        // index in `slice[..=first]`, therefore they can be skipped because
+        // [`sift_down`] orders them when the index of their parent is reached.
+        let last = parent(elements.len() - 1);
+
+        // By going in reverse, since children of `node` will either be leaves
+        // or subtrees already heap ordered, therefore sift it down until the
+        // tree rooted at `node` is itself heap ordered.
+        for node in (0..=last).rev() {
+            sift_down::top_down(&mut elements[node..]);
         }
     }
 

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -30,7 +30,7 @@ pub fn bottom_up<T: Ord>(elements: &mut [T]) {
         elements.swap(0, sorted);
 
         let Some(heap) = elements.get_mut(..sorted) else {
-            unreachable!("the last leaf is less than the length");
+            unreachable!("loop ensures within bounds");
         };
 
         // Sift down the leaf into the max-heap (excluding sorted elements).
@@ -120,17 +120,20 @@ pub fn inline<T: Ord>(elements: &mut [T]) {
 ///
 /// assert_eq!(elements, [0, 1, 2, 3, 4, 5]);
 /// ```
-#[allow(clippy::indexing_slicing)]
 pub fn top_down<T: Ord>(elements: &mut [T]) {
     // Order `elements` in max-heap order, hence `elements[0]` is the greatest.
     construct_heap::top_down(elements);
 
-    for end in (0..elements.len()).rev() {
+    for sorted in (0..elements.len()).rev() {
         // Place the greatest element not yet sorted into sorted order.
-        elements.swap(0, end);
+        elements.swap(0, sorted);
+
+        let Some(heap) = elements.get_mut(..sorted) else {
+            unreachable!("loop ensures within bounds");
+        };
 
         // Sift down the leaf into the max-heap (excluding sorted elements).
-        sift_down::top_down(&mut elements[..end]);
+        sift_down::top_down(heap);
     }
 }
 

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -108,13 +108,13 @@ mod max_heapify {
     /// Arrange `element` into max-heap (children less than parent) order.
     ///
     /// # Performance
-    /// This method takes O(N log N) time and consumes O(1) memory.
+    /// This method takes O(N) time and consumes O(1) memory.
     pub(super) fn bottom_up<T: Ord>(elements: &mut [T]) {
         if elements.len() <= 1 {
             return;
         }
 
-        let last_parent = parent(elements.len() - 1);
+        let last_parent = parent(elements.len() - 1) + 1;
 
         for parent in (0..=last_parent).rev() {
             // The children of `node` are already heap ordered, so sift down.
@@ -125,7 +125,7 @@ mod max_heapify {
     /// Arrange `element` into max-heap (children less than parent) order.
     ///
     /// # Performance
-    /// This method takes O(N) time and consumes O(1) memory.
+    /// This method takes O(N * log N) time and consumes O(1) memory.
     pub(super) fn top_down<T: Ord>(elements: &mut [T]) {
         for leaf in 1..=elements.len() {
             // The ancestors of `leaf` are already heap ordered, so sift up.

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -143,7 +143,7 @@ pub fn top_down<T: Ord>(elements: &mut [T]) {
 /// This method takes O(1) time and consumes O(1) memory.
 #[inline]
 fn left_child(root: usize) -> Option<usize> {
-    index.checked_mul(2).and_then(|index| index.checked_add(1))
+    root.checked_mul(2).and_then(|index| index.checked_add(1))
 }
 
 /// Index of the right child of the node at `root` in a binary heap.
@@ -152,16 +152,16 @@ fn left_child(root: usize) -> Option<usize> {
 /// This method takes O(1) time and consumes O(1) memory.
 #[inline]
 fn right_child(root: usize) -> Option<usize> {
-    index.checked_mul(2).and_then(|index| index.checked_add(2))
+    root.checked_mul(2).and_then(|index| index.checked_add(2))
 }
 
-/// Index of the parent of the node at `root` in a binary heap.
+/// Index of the parent of the node at `child` in a binary heap.
 ///
 /// # Performance
 /// This method takes O(1) time and consumes O(1) memory.
 #[inline]
-fn parent(root: usize) -> Option<usize> {
-    index.checked_sub(1).map(|index| index / 2)
+fn parent(child: usize) -> Option<usize> {
+    child.checked_sub(1).map(|index| index / 2)
 }
 
 /// Sift the last leaf of a `max_heap` up to the correct position.

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -99,6 +99,7 @@ mod sift_down {
     }
 }
 
+/// Construct a binary max-heap.
 mod max_heapify {
     use super::*;
 

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -134,13 +134,13 @@ mod max_heapify {
     }
 }
 
-/// Sort a slice via bottom-up heap sort.
+/// Sort `elements` via bottom-up heap sort.
 ///
-/// Create bottom order heaps with one parent and two leaves. Iteratively join
-/// these heaps by 'sifting down' the element corresponding to their parent in
-/// the slice until all elements are within one max-heap.Ordered elements are
-/// then popped from the heap by swapping it with a leaf then 'sift down' to
-/// preserve order.
+/// Starting from lone elements which are themselves max-heap ordered,
+/// iteratively join these subtrees by sifting down the element corresponding
+/// to their parent until all elements are ordered. The max element (the root)
+/// can then be swapped with the leaf with the highest index thereby placing it
+/// in sorted order, sifting down the leaf to maintain ordering of the heap.
 ///
 /// # Examples
 /// ```
@@ -149,20 +149,17 @@ mod max_heapify {
 /// bottom_up(&mut slice);
 /// assert_eq!(slice, [1, 2, 3]);
 /// ```
-pub fn bottom_up<T>(slice: &mut [T])
-where
-    T: Ord,
-{
-    max_heapify::bottom_up(slice);
+pub fn bottom_up<T: Ord>(elements: &mut [T]) {
+    max_heapify::bottom_up(elements);
 
-    for end in (0..slice.len()).rev() {
+    for end in (0..elements.len()).rev() {
         // max-heap implies the root node is the greatest in the collection,
         // pop it from the max-heap by swapping it with the last element.
-        slice.swap(0, end);
+        elements.swap(0, end);
 
         // push the new root into the shrunk max-heap excluding sorted element.
         // sift_down(&mut max_heap[..end]);
-        sift_down::bottom_up(&mut slice[..end]);
+        sift_down::bottom_up(&mut elements[..end]);
     }
 }
 

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -311,23 +311,25 @@ mod bottom_up_inline {
     }
 }
 
-/// Reorder last leaf of a binary max-heap ordered slice.
+/// Sift the last leaf of a `max_heap` up to the correct position.
 ///
-/// Swap the last element (final leaf) with its parent until it is ordered
-/// within the max-heap.
-fn sift_up<T>(slice: &mut [T])
-where
-    T: Ord,
-{
-    if slice.len() > 1 {
-        let current_index = slice.len() - 1;
-        let parent_index = parent(current_index);
+/// Swap the leaf with its parent until the parent is greater.
+///
+/// # Performance
+/// This method takes O(log N) time and consumes O(1) memory.
+fn sift_up<T: Ord>(max_heap: &mut [T]) {
+    if max_heap.len() <= 1 {
+        return;
+    }
 
-        if let (Some(current), Some(parent)) = (slice.get(current_index), slice.get(parent_index)) {
-            if parent < current {
-                slice.swap(current_index, parent_index);
-                sift_up(&mut slice[..=parent_index]);
-            }
+    let mut current = max_heap.len() - 1;
+
+    while current > 0 {
+        if max_heap[parent(current)] < max_heap[current] {
+            max_heap.swap(current, parent(current));
+            current = parent(current);
+        } else {
+            return;
         }
     }
 }

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -8,7 +8,7 @@ fn left_child(index: usize) -> usize {
     2 * index + 1
 }
 
-/// Index of the right child of  the node at`index` in a binary heap.
+/// Index of the right child of the node at `index` in a binary heap.
 fn right_child(index: usize) -> usize {
     2 * index + 2
 }

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -1,12 +1,4 @@
 //! Implementations of [Heap Sort](https://en.wikipedia.org/wiki/Heapsort).
-//!
-//! # Performance
-//!
-//! | Case    | Complexity |
-//! | ------- | ---------- |
-//! | worst   | n log n    |
-//! | average | n log n    |
-//! | best    | n log n    |
 
 /// Index of the left child of the node at `index` in a binary heap.
 fn left_child(index: usize) -> usize {

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -313,7 +313,7 @@ mod construct_heap {
 
         for parent in (0..=last_parent).rev() {
             let Some(heap) = elements.get_mut(parent..) else {
-                unreachable!("obviously in bounds");
+                unreachable!("loop condition ensures in bounds");
             };
 
             // The children of `node` are already heap ordered, so sift down.
@@ -325,11 +325,14 @@ mod construct_heap {
     ///
     /// # Performance
     /// This method takes O(N * log N) time and consumes O(1) memory.
-    #[allow(clippy::indexing_slicing)]
     pub(super) fn top_down<T: Ord>(elements: &mut [T]) {
         for leaf in 1..=elements.len() {
+            let Some(heap) = elements.get_mut(..leaf) else {
+                unreachable!("loop condition ensures in bounds");
+            };
+
             // The ancestors of `leaf` are already heap ordered, so sift up.
-            sift_up(&mut elements[..leaf]);
+            sift_up(heap);
         }
     }
 }

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -300,7 +300,6 @@ mod sift_down {
 
 /// Construct a binary max-heap (also known as heapify).
 mod construct_heap {
-    use super::parent;
     use super::sift_down;
     use super::sift_up;
 
@@ -308,18 +307,17 @@ mod construct_heap {
     ///
     /// # Performance
     /// This method takes O(N) time and consumes O(1) memory.
-    #[allow(clippy::arithmetic_side_effects)]
-    #[allow(clippy::indexing_slicing)]
     pub(super) fn bottom_up<T: Ord>(elements: &mut [T]) {
-        if elements.len() <= 1 {
-            return;
-        }
-
-        let last_parent = parent(elements.len() - 1) + 1;
+        // All leaves will be ordered when their parent is sifted down.
+        let last_parent = elements.len() / 2;
 
         for parent in (0..=last_parent).rev() {
+            let Some(heap) = elements.get_mut(parent..) else {
+                unreachable!("obviously in bounds");
+            };
+
             // The children of `node` are already heap ordered, so sift down.
-            sift_down::top_down(&mut elements[parent..]);
+            sift_down::top_down(heap);
         }
     }
 

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -20,22 +20,22 @@ fn parent(index: usize) -> usize {
 
 /// Move a misplaced node down a heap into the correct level.
 mod sift_down {
-    use super::parent;
     use super::left_child;
+    use super::parent;
     use super::right_child;
 
-    /// Reorder root (first element) of a binary max-heap ordered slice.
+    /// Sift the root of a binary `max_heap` down to the correct position.
     ///
-    /// Swap the first element (current root) with the greatest root of either
-    /// the left or right child max-heap until the subtree rooted by the first
-    /// element is itself a valid max-heap.
-    pub(super) fn top_down<T>(slice: &mut [T])
-    where
-        T: Ord,
-    {
+    /// Swap the current root with the greatest child until both children are
+    /// less than that root, thereby repairing a max-heap with invalid root.
+    ///
+    /// # Performance
+    /// This method takes O(log N) time and consumes O(log N) memory.
+    pub(super) fn top_down<T: Ord>(max_heap: &mut [T]) {
         let root = 0;
-        if let Some(left) = slice.get(left_child(root)) {
-            let child = if slice
+
+        if let Some(left) = max_heap.get(left_child(root)) {
+            let child = if max_heap
                 .get(right_child(root))
                 .is_some_and(|right| left < right)
             {
@@ -44,9 +44,9 @@ mod sift_down {
                 left_child(root)
             };
 
-            if slice[child] > slice[root] {
-                slice.swap(root, child);
-                top_down(&mut slice[child..])
+            if max_heap[child] > max_heap[root] {
+                max_heap.swap(root, child);
+                top_down(&mut max_heap[child..]);
             }
         }
     }

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -212,24 +212,30 @@ mod sift_down {
     ///
     /// # Performance
     /// This method takes O(log N) time and consumes O(1) memory.
-    #[allow(clippy::indexing_slicing)]
     pub(super) fn top_down<T: Ord>(max_heap: &mut [T]) {
-        let mut root = 0;
+        let mut root_index = 0;
 
-        while left_child(root) < max_heap.len() {
-            let greatest_child = if right_child(root) < max_heap.len()
-                && max_heap[left_child(root)] < max_heap[right_child(root)]
+        while let Some(left) = max_heap.get(left_child(root_index)) {
+            let child_index = if max_heap
+                .get(right_child(root_index))
+                .is_some_and(|right| left < right)
             {
-                right_child(root)
+                right_child(root_index)
             } else {
-                left_child(root)
+                left_child(root_index)
             };
 
-            if max_heap[root] < max_heap[greatest_child] {
-                max_heap.swap(root, greatest_child);
-                root = greatest_child;
+            let (Some(root_element), Some(child_element)) =
+                (max_heap.get(root_index), max_heap.get(child_index))
+            else {
+                unreachable!("in the loop => child exists => root exists");
+            };
+
+            if root_element < child_element {
+                max_heap.swap(root_index, child_index);
+                root_index = child_index;
             } else {
-                return;
+                break;
             }
         }
     }

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -215,7 +215,9 @@ mod sift_down {
         let mut root_index = 0;
 
         loop {
-            let (Some(left_child), Some(right_child)) = (left_child(root_index), right_child(root_index)) else {
+            let (Some(left_child), Some(right_child)) =
+                (left_child(root_index), right_child(root_index))
+            else {
                 unreachable!("loop prevents a root without children big enough to overflow");
             };
 
@@ -226,13 +228,15 @@ mod sift_down {
                     } else {
                         left_child
                     }
-                },
+                }
                 (Some(_), None) => left_child,
                 (None, Some(_)) => unreachable!("left has smaller index"),
                 (None, None) => break,
             };
 
-            let (Some(root_element), Some(child_element)) = (max_heap.get(root_index), max_heap.get(child_index)) else {
+            let (Some(root_element), Some(child_element)) =
+                (max_heap.get(root_index), max_heap.get(child_index))
+            else {
                 unreachable!("in the loop => child exists => root exists");
             };
 
@@ -261,7 +265,8 @@ mod sift_down {
 
         // Traverse down to leaf where the smallest possible value goes.
         loop {
-            let (Some(left_child), Some(right_child)) = (left_child(current), right_child(current)) else {
+            let (Some(left_child), Some(right_child)) = (left_child(current), right_child(current))
+            else {
                 unreachable!("loop prevents a root without children big enough to overflow");
             };
 

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -114,18 +114,11 @@ mod max_heapify {
             return;
         }
 
-        // `last` is the parent of the last element hence it is the greatest
-        // index of a node in the heap which has children. Since elements
-        // within `slice[first..]` are leaves to some subtree rooted by an
-        // index in `slice[..=first]`, therefore they can be skipped because
-        // [`sift_down`] orders them when the index of their parent is reached.
-        let last = parent(elements.len() - 1);
+        let last_parent = parent(elements.len() - 1);
 
-        // By going in reverse, since children of `node` will either be leaves
-        // or subtrees already heap ordered, therefore sift it down until the
-        // tree rooted at `node` is itself heap ordered.
-        for node in (0..=last).rev() {
-            sift_down::top_down(&mut elements[node..]);
+        for parent in (0..=last_parent).rev() {
+            // The children of `node` are already heap ordered, so sift down.
+            sift_down::top_down(&mut elements[parent..]);
         }
     }
 
@@ -135,7 +128,7 @@ mod max_heapify {
     /// This method takes O(N) time and consumes O(1) memory.
     pub(super) fn top_down<T: Ord>(elements: &mut [T]) {
         for leaf in 1..=elements.len() {
-            // push leaf into the max-heap
+            // The ancestors of `leaf` are already heap ordered, so sift up.
             sift_up(&mut elements[..leaf]);
         }
     }

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -251,38 +251,48 @@ mod sift_down {
     ///
     /// # Performance
     /// This method takes O(log N) time and consumes O(1) memory.
-    #[allow(clippy::indexing_slicing)]
     pub(super) fn bottom_up<T: Ord>(max_heap: &mut [T]) {
-        /// The absolute root of `max_heap` is this index.
-        const ROOT: usize = 0;
-
-        if max_heap.is_empty() {
-            return;
-        }
-
-        let mut current = ROOT;
+        let mut current = 0;
 
         // Traverse down to leaf where the smallest possible value goes.
-        while right_child(current) < max_heap.len() {
-            if max_heap[right_child(current)] > max_heap[left_child(current)] {
-                current = right_child(current);
-            } else {
-                current = left_child(current);
+        loop {
+            let left_child = left_child(current);
+            let right_child = right_child(current);
+
+            current = match (max_heap.get(left_child), max_heap.get(right_child)) {
+                (Some(left), Some(right)) => {
+                    if right > left {
+                        right_child
+                    } else {
+                        left_child
+                    }
+                }
+                (Some(_), None) => left_child,
+                (None, Some(_)) => unreachable!("left has smaller index"),
+                (None, None) => break,
             }
         }
 
-        if left_child(current) < max_heap.len() {
-            current = left_child(current);
-        }
-
         // Traverse upwards from that leaf to find where root should go.
-        while max_heap[ROOT] > max_heap[current] {
-            current = parent(current);
+        loop {
+            let Some(root) = max_heap.first() else {
+                return;
+            };
+
+            let Some(element) = max_heap.get(current) else {
+                unreachable!("above loop will ensure within bounds");
+            };
+
+            if root > element {
+                current = parent(current);
+            } else {
+                break;
+            }
         }
 
         // Swap root into that position and propagate upwards.
-        while current > ROOT {
-            max_heap.swap(ROOT, current);
+        while current > 0 {
+            max_heap.swap(0, current);
             current = parent(current);
         }
     }

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -30,23 +30,24 @@ mod sift_down {
     /// less than that root, thereby repairing a max-heap with invalid root.
     ///
     /// # Performance
-    /// This method takes O(log N) time and consumes O(log N) memory.
+    /// This method takes O(log N) time and consumes O(1) memory.
     pub(super) fn top_down<T: Ord>(max_heap: &mut [T]) {
-        let root = 0;
+        let mut root = 0;
 
-        if let Some(left) = max_heap.get(left_child(root)) {
-            let child = if max_heap
-                .get(right_child(root))
-                .is_some_and(|right| left < right)
+        while left_child(root) < max_heap.len() {
+            let greatest_child = if right_child(root) < max_heap.len()
+                && max_heap[left_child(root)] < max_heap[right_child(root)]
             {
                 right_child(root)
             } else {
                 left_child(root)
             };
 
-            if max_heap[child] > max_heap[root] {
-                max_heap.swap(root, child);
-                top_down(&mut max_heap[child..]);
+            if max_heap[root] < max_heap[greatest_child] {
+                max_heap.swap(root, greatest_child);
+                root = greatest_child;
+            } else {
+                return;
             }
         }
     }

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -168,53 +168,6 @@ pub fn bottom_up<T: Ord>(elements: &mut [T]) {
     }
 }
 
-#[cfg(test)]
-mod bottom_up {
-    use super::bottom_up;
-
-    #[test]
-    fn empty() {
-        let mut slice: [usize; 0] = [];
-        bottom_up(&mut slice);
-        assert_eq!(slice, []);
-    }
-
-    #[test]
-    fn single() {
-        let mut slice = [0];
-        bottom_up(&mut slice);
-        assert_eq!(slice, [0]);
-    }
-
-    #[test]
-    fn sorted() {
-        let mut slice = [0, 1];
-        bottom_up(&mut slice);
-        assert_eq!(slice, [0, 1]);
-    }
-
-    #[test]
-    fn must_swap() {
-        let mut slice = [1, 0];
-        bottom_up(&mut slice);
-        assert_eq!(slice, [0, 1]);
-    }
-
-    #[test]
-    fn odd_length() {
-        let mut slice = [3, 2, 1];
-        bottom_up(&mut slice);
-        assert_eq!(slice, [1, 2, 3]);
-    }
-
-    #[test]
-    fn multiple_swap() {
-        let mut slice = [2, 0, 3, 1];
-        bottom_up(&mut slice);
-        assert_eq!(slice, [0, 1, 2, 3]);
-    }
-}
-
 /// Sort `elements` via bottom-up heap sort with inline sift-down optimization.
 ///
 /// The implementation of [`bottom_up`] first creates a max-heap, and then
@@ -261,53 +214,6 @@ pub fn bottom_up_inline<T: Ord>(elements: &mut [T]) {
         }
 
         sift_down::top_down(&mut elements[heap..left_unsorted]);
-    }
-}
-
-#[cfg(test)]
-mod bottom_up_inline {
-    use super::bottom_up_inline;
-
-    #[test]
-    fn empty() {
-        let mut slice: [usize; 0] = [];
-        bottom_up_inline(&mut slice);
-        assert_eq!(slice, []);
-    }
-
-    #[test]
-    fn single() {
-        let mut slice = [0];
-        bottom_up_inline(&mut slice);
-        assert_eq!(slice, [0]);
-    }
-
-    #[test]
-    fn sorted() {
-        let mut slice = [0, 1];
-        bottom_up_inline(&mut slice);
-        assert_eq!(slice, [0, 1]);
-    }
-
-    #[test]
-    fn must_swap() {
-        let mut slice = [1, 0];
-        bottom_up_inline(&mut slice);
-        assert_eq!(slice, [0, 1]);
-    }
-
-    #[test]
-    fn odd_length() {
-        let mut slice = [3, 2, 1];
-        bottom_up_inline(&mut slice);
-        assert_eq!(slice, [1, 2, 3]);
-    }
-
-    #[test]
-    fn multiple_swap() {
-        let mut slice = [2, 0, 3, 1];
-        bottom_up_inline(&mut slice);
-        assert_eq!(slice, [0, 1, 2, 3]);
     }
 }
 
@@ -369,48 +275,187 @@ pub fn top_down<T: Ord>(elements: &mut [T]) {
 }
 
 #[cfg(test)]
-mod top_down {
-    use super::top_down;
+#[allow(
+    clippy::undocumented_unsafe_blocks,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::assertions_on_result_states,
+    clippy::indexing_slicing
+)]
+mod test {
+    use super::*;
 
-    #[test]
-    fn empty() {
-        let mut slice: [usize; 0] = [];
-        top_down(&mut slice);
-        assert_eq!(slice, []);
+    mod bottom_up {
+        use super::*;
+
+        #[test]
+        fn empty() {
+            let mut elements = [usize::default(); 0];
+
+            bottom_up(&mut elements);
+
+            assert_eq!(elements, []);
+        }
+
+        #[test]
+        fn single_element() {
+            let mut elements = [0];
+
+            bottom_up(&mut elements);
+
+            assert_eq!(elements, [0]);
+        }
+
+        #[test]
+        fn already_sorted() {
+            let mut elements = [0, 1, 2, 3, 4, 5];
+
+            bottom_up(&mut elements);
+
+            assert_eq!(elements, [0, 1, 2, 3, 4, 5]);
+        }
+
+        #[test]
+        fn must_swap() {
+            let mut elements = [1, 0];
+
+            bottom_up(&mut elements);
+
+            assert_eq!(elements, [0, 1]);
+        }
+
+        #[test]
+        fn odd_length() {
+            let mut elements = [2, 1, 0];
+
+            bottom_up(&mut elements);
+
+            assert_eq!(elements, [0, 1, 2]);
+        }
+
+        #[test]
+        fn multiple_swaps() {
+            let mut elements = [2, 0, 3, 1];
+
+            bottom_up(&mut elements);
+
+            assert_eq!(elements, [0, 1, 2, 3]);
+        }
     }
 
-    #[test]
-    fn single() {
-        let mut slice = [0];
-        top_down(&mut slice);
-        assert_eq!(slice, [0]);
+    mod inline {
+        use super::*;
+
+        #[test]
+        fn empty() {
+            let mut elements = [usize::default(); 0];
+
+            bottom_up_inline(&mut elements);
+
+            assert_eq!(elements, []);
+        }
+
+        #[test]
+        fn single_element() {
+            let mut elements = [0];
+
+            bottom_up_inline(&mut elements);
+
+            assert_eq!(elements, [0]);
+        }
+
+        #[test]
+        fn already_sorted() {
+            let mut elements = [0, 1, 2, 3, 4, 5];
+
+            bottom_up_inline(&mut elements);
+
+            assert_eq!(elements, [0, 1, 2, 3, 4, 5]);
+        }
+
+        #[test]
+        fn must_swap() {
+            let mut elements = [1, 0];
+
+            bottom_up_inline(&mut elements);
+
+            assert_eq!(elements, [0, 1]);
+        }
+
+        #[test]
+        fn odd_length() {
+            let mut elements = [2, 1, 0];
+
+            bottom_up_inline(&mut elements);
+
+            assert_eq!(elements, [0, 1, 2]);
+        }
+
+        #[test]
+        fn multiple_swaps() {
+            let mut elements = [2, 0, 3, 1];
+
+            bottom_up_inline(&mut elements);
+
+            assert_eq!(elements, [0, 1, 2, 3]);
+        }
     }
 
-    #[test]
-    fn sorted() {
-        let mut slice = [0, 1];
-        top_down(&mut slice);
-        assert_eq!(slice, [0, 1]);
-    }
+    mod top_down {
+        use super::*;
 
-    #[test]
-    fn must_swap() {
-        let mut slice = [1, 0];
-        top_down(&mut slice);
-        assert_eq!(slice, [0, 1]);
-    }
+        #[test]
+        fn empty() {
+            let mut elements = [usize::default(); 0];
 
-    #[test]
-    fn odd_length() {
-        let mut slice = [3, 2, 1];
-        top_down(&mut slice);
-        assert_eq!(slice, [1, 2, 3]);
-    }
+            top_down(&mut elements);
 
-    #[test]
-    fn multiple_swap() {
-        let mut slice = [2, 0, 3, 1];
-        top_down(&mut slice);
-        assert_eq!(slice, [0, 1, 2, 3]);
+            assert_eq!(elements, []);
+        }
+
+        #[test]
+        fn single_element() {
+            let mut elements = [0];
+
+            top_down(&mut elements);
+
+            assert_eq!(elements, [0]);
+        }
+
+        #[test]
+        fn already_sorted() {
+            let mut elements = [0, 1, 2, 3, 4, 5];
+
+            top_down(&mut elements);
+
+            assert_eq!(elements, [0, 1, 2, 3, 4, 5]);
+        }
+
+        #[test]
+        fn must_swap() {
+            let mut elements = [1, 0];
+
+            top_down(&mut elements);
+
+            assert_eq!(elements, [0, 1]);
+        }
+
+        #[test]
+        fn odd_length() {
+            let mut elements = [2, 1, 0];
+
+            top_down(&mut elements);
+
+            assert_eq!(elements, [0, 1, 2]);
+        }
+
+        #[test]
+        fn multiple_swaps() {
+            let mut elements = [2, 0, 3, 1];
+
+            top_down(&mut elements);
+
+            assert_eq!(elements, [0, 1, 2, 3]);
+        }
     }
 }

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -105,44 +105,36 @@ mod max_heapify {
     use super::sift_down;
     use super::sift_up;
 
-    /// Arrange elements of a slice into max-heap order in O(n log n) time.
+    /// Arrange `element` into max-heap (children less than parent) order.
     ///
-    /// Interpret `slice` as a binary tree where, for each node at index i, the
-    /// left child is at index (2*i+1) and the right child is at index (2*i+2).
-    /// Reorder the nodes such that all children are less than their parent.
-    pub(super) fn bottom_up<T>(slice: &mut [T])
-    where
-        T: Ord,
-    {
-        if slice.len() > 1 {
+    /// # Performance
+    /// This method takes O(N log N) time and consumes O(1) memory.
+    pub(super) fn bottom_up<T: Ord>(elements: &mut [T]) {
+        if elements.len() > 1 {
             // `last` is the parent of the last element hence it is the greatest
             // index of a node in the heap which has children. Since elements
             // within `slice[first..]` are leaves to some subtree rooted by an
             // index in `slice[..=first]`, therefore they can be skipped because
             // [`sift_down`] orders them when the index of their parent is reached.
-            let last = parent(slice.len() - 1);
+            let last = parent(elements.len() - 1);
 
             // By going in reverse, since children of `node` will either be leaves
             // or subtrees already heap ordered, therefore sift it down until the
             // tree rooted at `node` is itself heap ordered.
             for node in (0..=last).rev() {
-                sift_down::top_down(&mut slice[node..]);
+                sift_down::top_down(&mut elements[node..]);
             }
         }
     }
 
-    /// Arrange elements of a slice into max-heap order in O(n) time.
+    /// Arrange `element` into max-heap (children less than parent) order.
     ///
-    /// Interpret `slice` as a binary tree where, for each node at index i, the
-    /// left child is at index (2*i+1) and the right child is at index (2*i+2).
-    /// Reorder the nodes such that all children are less than their parent.
-    pub(super) fn top_down<T>(slice: &mut [T])
-    where
-        T: Ord,
-    {
-        for leaf in 1..=slice.len() {
+    /// # Performance
+    /// This method takes O(N) time and consumes O(1) memory.
+    pub(super) fn top_down<T: Ord>(elements: &mut [T]) {
+        for leaf in 1..=elements.len() {
             // push leaf into the max-heap
-            sift_up(&mut slice[..leaf]);
+            sift_up(&mut elements[..leaf]);
         }
     }
 }

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -40,7 +40,7 @@ pub fn bottom_up<T: Ord>(elements: &mut [T]) {
 /// The implementation of [`bottom_up`] first creates a max-heap, and then
 /// separately uses that structure to obtain elements in sorted order thereby
 /// having two independent execution paths which ultimately invoke
-/// [`sift_down`]. In contrast, this implementation combines both steps with
+/// `sift_down`. In contrast, this implementation combines both steps with
 /// one shared execution path which would likely result in different runtime
 /// characteristics given branch prediction and potential inline expansion.
 ///

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -20,7 +20,9 @@ fn parent(index: usize) -> usize {
 
 /// Move a misplaced node down a heap into the correct level.
 mod sift_down {
-    use super::*;
+    use super::parent;
+    use super::left_child;
+    use super::right_child;
 
     /// Reorder root (first element) of a binary max-heap ordered slice.
     ///

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -137,30 +137,30 @@ pub fn top_down<T: Ord>(elements: &mut [T]) {
     }
 }
 
-/// Index of the left child of the node at `index` in a binary heap.
+/// Index of the left child of the node at `root` in a binary heap.
 ///
 /// # Performance
 /// This method takes O(1) time and consumes O(1) memory.
 #[inline]
-fn left_child(index: usize) -> Option<usize> {
+fn left_child(root: usize) -> Option<usize> {
     index.checked_mul(2).and_then(|index| index.checked_add(1))
 }
 
-/// Index of the right child of the node at `index` in a binary heap.
+/// Index of the right child of the node at `root` in a binary heap.
 ///
 /// # Performance
 /// This method takes O(1) time and consumes O(1) memory.
 #[inline]
-fn right_child(index: usize) -> Option<usize> {
+fn right_child(root: usize) -> Option<usize> {
     index.checked_mul(2).and_then(|index| index.checked_add(2))
 }
 
-/// Index of the parent of the node at `index` in a binary heap.
+/// Index of the parent of the node at `root` in a binary heap.
 ///
 /// # Performance
 /// This method takes O(1) time and consumes O(1) memory.
 #[inline]
-fn parent(index: usize) -> Option<usize> {
+fn parent(root: usize) -> Option<usize> {
     index.checked_sub(1).map(|index| index / 2)
 }
 

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -334,32 +334,37 @@ fn sift_up<T: Ord>(max_heap: &mut [T]) {
     }
 }
 
-/// Sort a slice via top-down heap sort.
+/// Sort `elements` via top-down heap sort.
 ///
-/// Create one max-heap at the start of the slice and then push each successive
-/// element into it by 'sifting up'. Ordered elements are then popped from the
-/// heap by swapping it with a leaf then 'sifting down' to preserve the heap.
+/// Create one max-heap containing the first element, add the next element as a
+/// leaf to that heap sifting it up as necessary, repeating until all elements
+/// are ordered. The max element (the root) can then be swapped with the leaf
+/// with the highest index thereby placing it in sorted order, sifting down the
+/// leaf to maintain ordering of the heap.
+///
+/// # Performance
+/// This method takes O(N * log N) time and consumes O(1) memory.
 ///
 /// # Examples
 /// ```
 /// use rust::algorithm::sort::comparison::heap::top_down;
-/// let mut slice = [3, 2, 1];
-/// top_down(&mut slice);
-/// assert_eq!(slice, [1, 2, 3]);
+///
+/// let mut elements = [0, 5, 2, 3, 1, 4];
+///
+/// top_down(&mut elements);
+///
+/// assert_eq!(elements, [0, 1, 2, 3, 4, 5]);
 /// ```
-pub fn top_down<T>(slice: &mut [T])
-where
-    T: Ord,
-{
-    max_heapify::top_down(slice);
+pub fn top_down<T: Ord>(elements: &mut [T]) {
+    // Order `elements` in max-heap order, hence `elements[0]` is the greatest.
+    max_heapify::top_down(elements);
 
-    for end in (0..slice.len()).rev() {
-        // max-heap implies the root node is the greatest in the collection,
-        // pop it from the max-heap by swapping it with the last element.
-        slice.swap(0, end);
+    for end in (0..elements.len()).rev() {
+        // Place the greatest element not yet sorted into sorted order.
+        elements.swap(0, end);
 
-        // push the new root into the shrunk max-heap excluding sorted element.
-        sift_down::top_down(&mut slice[..end]);
+        // Sift down the leaf into the max-heap (excluding sorted elements).
+        sift_down::top_down(&mut elements[..end]);
     }
 }
 

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -121,16 +121,25 @@ pub fn top_down<T: Ord>(elements: &mut [T]) {
 }
 
 /// Index of the left child of the node at `index` in a binary heap.
+///
+/// # Performance
+/// This method takes O(1) time and consumes O(1) memory.
 fn left_child(index: usize) -> usize {
     2 * index + 1
 }
 
 /// Index of the right child of the node at `index` in a binary heap.
+///
+/// # Performance
+/// This method takes O(1) time and consumes O(1) memory.
 fn right_child(index: usize) -> usize {
     2 * index + 2
 }
 
 /// Index of the parent of the node at `index` in a binary heap.
+///
+/// # Performance
+/// This method takes O(1) time and consumes O(1) memory.
 fn parent(index: usize) -> usize {
     (index - 1) / 2
 }

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -21,17 +21,20 @@
 ///
 /// assert_eq!(elements, [0, 1, 2, 3, 4, 5]);
 /// ```
-#[allow(clippy::indexing_slicing)]
 pub fn bottom_up<T: Ord>(elements: &mut [T]) {
     // Order `elements` in max-heap order, hence `elements[0]` is the greatest.
     construct_heap::bottom_up(elements);
 
-    for end in (0..elements.len()).rev() {
+    for sorted in (0..elements.len()).rev() {
         // Place the greatest element not yet sorted into sorted order.
-        elements.swap(0, end);
+        elements.swap(0, sorted);
+
+        let Some(heap) = elements.get_mut(..sorted) else {
+            unreachable!("the last leaf is less than the length");
+        };
 
         // Sift down the leaf into the max-heap (excluding sorted elements).
-        sift_down::bottom_up(&mut elements[..end]);
+        sift_down::bottom_up(heap);
     }
 }
 

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -52,38 +52,49 @@ mod sift_down {
         }
     }
 
-    pub(super) fn bottom_up<T>(slice: &mut [T], index: usize)
-    where
-        T: Ord,
-    {
-        fn leaf_search<T>(slice: &mut [T], mut index: usize) -> usize
-        where
-            T: Ord,
-        {
-            while right_child(index) < slice.len() {
-                if slice[right_child(index)] > slice[left_child(index)] {
-                    index = right_child(index);
-                } else {
-                    index = left_child(index);
-                }
-            }
+    /// Sift the root of a binary `max_heap` down to the correct position.
+    ///
+    /// Traverse the heap down to the leaves (this is presumably where the
+    /// current root value came from), and then traverse upward a node is found
+    /// which is greater than the value being sifted down.
+    ///
+    /// This uses fewer comparison than [`top_down`], but will likely have
+    /// worse performance for cheap comparisons.
+    ///
+    /// # Performance
+    /// This method takes O(log N) time and consumes O(1) memory.
+    pub(super) fn bottom_up<T: Ord>(max_heap: &mut [T]) {
+        /// The absolute root of `max_heap` is this index.
+        const ROOT: usize = 0;
 
-            if left_child(index) < slice.len() {
-                index = left_child(index);
-            }
-
-            index
+        if max_heap.is_empty() {
+            return;
         }
 
-        if !slice.is_empty() {
-            let mut leaf = leaf_search(slice, index);
-            while slice[index] > slice[leaf] {
-                leaf = parent(leaf);
+        let mut current = ROOT;
+
+        // Traverse down to leaf where the smallest possible value goes.
+        while right_child(current) < max_heap.len() {
+            if max_heap[right_child(current)] > max_heap[left_child(current)] {
+                current = right_child(current);
+            } else {
+                current = left_child(current);
             }
-            while leaf > index {
-                slice.swap(index, leaf);
-                leaf = parent(leaf);
-            }
+        }
+
+        if left_child(current) < max_heap.len() {
+            current = left_child(current);
+        }
+
+        // Traverse upwards from that leaf to find where root should go.
+        while max_heap[ROOT] > max_heap[current] {
+            current = parent(current);
+        }
+
+        // Swap root into that position and propagate upwards.
+        while current > ROOT {
+            max_heap.swap(ROOT, current);
+            current = parent(current);
         }
     }
 }
@@ -161,7 +172,7 @@ where
 
         // push the new root into the shrunk max-heap excluding sorted element.
         // sift_down(&mut max_heap[..end]);
-        sift_down::bottom_up(&mut slice[..end], 0);
+        sift_down::bottom_up(&mut slice[..end]);
     }
 }
 

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -101,7 +101,9 @@ mod sift_down {
 
 /// Construct a binary max-heap.
 mod max_heapify {
-    use super::*;
+    use super::parent;
+    use super::sift_down;
+    use super::sift_up;
 
     /// Arrange elements of a slice into max-heap order in O(n log n) time.
     ///

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -173,21 +173,28 @@ fn parent(index: usize) -> usize {
 ///
 /// # Performance
 /// This method takes O(log N) time and consumes O(1) memory.
-#[allow(clippy::arithmetic_side_effects)]
-#[allow(clippy::indexing_slicing)]
 fn sift_up<T: Ord>(max_heap: &mut [T]) {
-    if max_heap.len() <= 1 {
+    let Some(mut current_index) = max_heap.len().checked_sub(1) else {
+        debug_assert_eq!(max_heap.len(), 0, "only condition its none");
         return;
-    }
+    };
 
-    let mut current = max_heap.len() - 1;
+    while current_index > 0 {
+        let Some(current_element) = max_heap.get(current_index) else {
+            unreachable!("index only decreases, cannot be out of bounds");
+        };
 
-    while current > 0 {
-        if max_heap[parent(current)] < max_heap[current] {
-            max_heap.swap(current, parent(current));
-            current = parent(current);
+        let parent_index = parent(current_index);
+
+        let Some(parent_element) = max_heap.get(parent_index) else {
+            unreachable!("parent is between zero and current, thus in bounds");
+        };
+
+        if parent_element < current_element {
+            max_heap.swap(current_index, parent_index);
+            current_index = parent_index;
         } else {
-            return;
+            break;
         }
     }
 }

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -1,8 +1,5 @@
 //! Implementations of [Heap Sort](https://en.wikipedia.org/wiki/Heapsort).
 
-#![allow(clippy::arithmetic_side_effects)]
-#![allow(clippy::indexing_slicing)]
-
 /// Sort `elements` via bottom-up heap sort.
 ///
 /// Starting from lone elements which are themselves max-heap ordered,
@@ -24,6 +21,7 @@
 ///
 /// assert_eq!(elements, [0, 1, 2, 3, 4, 5]);
 /// ```
+#[allow(clippy::indexing_slicing)]
 pub fn bottom_up<T: Ord>(elements: &mut [T]) {
     // Order `elements` in max-heap order, hence `elements[0]` is the greatest.
     construct_heap::bottom_up(elements);
@@ -59,6 +57,8 @@ pub fn bottom_up<T: Ord>(elements: &mut [T]) {
 ///
 /// assert_eq!(elements, [0, 1, 2, 3, 4, 5]);
 /// ```
+#[allow(clippy::arithmetic_side_effects)]
+#[allow(clippy::indexing_slicing)]
 pub fn inline<T: Ord>(elements: &mut [T]) {
     // This is the parent of the last element, hence it is the greatest index
     // of a node in the heap which has children. Since leaf elements within
@@ -107,6 +107,7 @@ pub fn inline<T: Ord>(elements: &mut [T]) {
 ///
 /// assert_eq!(elements, [0, 1, 2, 3, 4, 5]);
 /// ```
+#[allow(clippy::indexing_slicing)]
 pub fn top_down<T: Ord>(elements: &mut [T]) {
     // Order `elements` in max-heap order, hence `elements[0]` is the greatest.
     construct_heap::top_down(elements);
@@ -125,6 +126,7 @@ pub fn top_down<T: Ord>(elements: &mut [T]) {
 /// # Performance
 /// This method takes O(1) time and consumes O(1) memory.
 #[inline]
+#[allow(clippy::arithmetic_side_effects)]
 fn left_child(index: usize) -> usize {
     2 * index + 1
 }
@@ -134,6 +136,7 @@ fn left_child(index: usize) -> usize {
 /// # Performance
 /// This method takes O(1) time and consumes O(1) memory.
 #[inline]
+#[allow(clippy::arithmetic_side_effects)]
 fn right_child(index: usize) -> usize {
     2 * index + 2
 }
@@ -143,6 +146,7 @@ fn right_child(index: usize) -> usize {
 /// # Performance
 /// This method takes O(1) time and consumes O(1) memory.
 #[inline]
+#[allow(clippy::arithmetic_side_effects)]
 fn parent(index: usize) -> usize {
     (index - 1) / 2
 }
@@ -153,6 +157,8 @@ fn parent(index: usize) -> usize {
 ///
 /// # Performance
 /// This method takes O(log N) time and consumes O(1) memory.
+#[allow(clippy::arithmetic_side_effects)]
+#[allow(clippy::indexing_slicing)]
 fn sift_up<T: Ord>(max_heap: &mut [T]) {
     if max_heap.len() <= 1 {
         return;
@@ -183,6 +189,7 @@ mod sift_down {
     ///
     /// # Performance
     /// This method takes O(log N) time and consumes O(1) memory.
+    #[allow(clippy::indexing_slicing)]
     pub(super) fn top_down<T: Ord>(max_heap: &mut [T]) {
         let mut root = 0;
 
@@ -215,6 +222,7 @@ mod sift_down {
     ///
     /// # Performance
     /// This method takes O(log N) time and consumes O(1) memory.
+    #[allow(clippy::indexing_slicing)]
     pub(super) fn bottom_up<T: Ord>(max_heap: &mut [T]) {
         /// The absolute root of `max_heap` is this index.
         const ROOT: usize = 0;
@@ -261,6 +269,8 @@ mod construct_heap {
     ///
     /// # Performance
     /// This method takes O(N) time and consumes O(1) memory.
+    #[allow(clippy::arithmetic_side_effects)]
+    #[allow(clippy::indexing_slicing)]
     pub(super) fn bottom_up<T: Ord>(elements: &mut [T]) {
         if elements.len() <= 1 {
             return;
@@ -278,6 +288,7 @@ mod construct_heap {
     ///
     /// # Performance
     /// This method takes O(N * log N) time and consumes O(1) memory.
+    #[allow(clippy::indexing_slicing)]
     pub(super) fn top_down<T: Ord>(elements: &mut [T]) {
         for leaf in 1..=elements.len() {
             // The ancestors of `leaf` are already heap ordered, so sift up.

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -148,9 +148,12 @@ mod max_heapify {
 /// # Examples
 /// ```
 /// use rust::algorithm::sort::comparison::heap::bottom_up;
-/// let mut slice = [1, 3, 2];
-/// bottom_up(&mut slice);
-/// assert_eq!(slice, [1, 2, 3]);
+///
+/// let mut elements = [0, 5, 2, 3, 1, 4];
+///
+/// bottom_up(&mut elements);
+///
+/// assert_eq!(elements, [0, 1, 2, 3, 4, 5]);
 /// ```
 pub fn bottom_up<T: Ord>(elements: &mut [T]) {
     max_heapify::bottom_up(elements);

--- a/src/algorithm/sort/comparison/heap.rs
+++ b/src/algorithm/sort/comparison/heap.rs
@@ -142,6 +142,9 @@ mod max_heapify {
 /// can then be swapped with the leaf with the highest index thereby placing it
 /// in sorted order, sifting down the leaf to maintain ordering of the heap.
 ///
+/// # Performance
+/// This method takes O(N log N) time and consumes O(1) memory.
+///
 /// # Examples
 /// ```
 /// use rust::algorithm::sort::comparison::heap::bottom_up;

--- a/src/algorithm/sort/comparison/merge.rs
+++ b/src/algorithm/sort/comparison/merge.rs
@@ -193,7 +193,7 @@ pub fn in_place<T: Ord>(elements: &mut [T]) {
         return;
     }
 
-    // Sort left half ([..middle]) into right half ().
+    // Sort left half `..middle` into right half `middle..`.
     let middle = elements.len() / 2;
     let mut output = elements.len() - middle;
     sort_into(elements, 0..middle, output);


### PR DESCRIPTION
### Description

Closes #94 

### Checklist

#### Documentation

- [x] Public **and** private symbols described?
- [x] Performance considerations for all subroutines?
  - [x] Time complexity?
  - [x] Memory complexity?
- [x] Examples for public interfaces?
  - [x] `cargo test --doc` passes?
- [x] `cargo doc --document-private-items` passes?

#### Testing

- [x] All post-conditions tested?
- [x] Dedicated tests for edge-cases?
- [x] Naming consistent with existing body?
- [x] Organized into a module hierarchy?
- [x] `cargo test --tests` passes?
- [x] `MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo +nightly miri test` passes?

#### Style

- [x] Considered [exception safety](https://doc.rust-lang.org/nomicon/exception-safety.html)?
- [x] `cargo check` passes?
- [x] `cargo clippy` passes?
- [x] `cargo fmt` passes?

#### Chores

- [x] Bumped version?
- [x] Added link to readme?
- [x] Rebased branch for clean commit history?
