### PR TITLE
globally disable lints in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "rust"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2021"
 
 authors = ["Tyler St. Onge <tyler@stonge.dev>"]

--- a/src/algorithm/merge.rs
+++ b/src/algorithm/merge.rs
@@ -167,13 +167,6 @@ pub fn in_place<T: Ord>(elements: &mut [T], middle: usize) {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::assertions_on_result_states,
-    clippy::indexing_slicing
-)]
 mod test {
     use super::*;
 

--- a/src/algorithm/search.rs
+++ b/src/algorithm/search.rs
@@ -87,13 +87,6 @@ pub fn binary<T: Ord + core::fmt::Debug>(haystack: &[T], needle: &T) -> Option<u
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::assertions_on_result_states,
-    clippy::indexing_slicing
-)]
 mod test {
     use super::*;
 

--- a/src/algorithm/sort/bubble.rs
+++ b/src/algorithm/sort/bubble.rs
@@ -290,13 +290,6 @@ pub fn comb<T: Ord>(elements: &mut [T]) {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::assertions_on_result_states,
-    clippy::indexing_slicing
-)]
 mod test {
     use super::*;
 

--- a/src/algorithm/sort/heap.rs
+++ b/src/algorithm/sort/heap.rs
@@ -358,13 +358,6 @@ mod construct_heap {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::assertions_on_result_states,
-    clippy::indexing_slicing
-)]
 mod test {
     use super::*;
 

--- a/src/algorithm/sort/insertion.rs
+++ b/src/algorithm/sort/insertion.rs
@@ -257,13 +257,6 @@ pub fn shell<T: Ord>(elements: &mut [T]) {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::assertions_on_result_states,
-    clippy::indexing_slicing
-)]
 mod test {
     use super::*;
 

--- a/src/algorithm/sort/merge.rs
+++ b/src/algorithm/sort/merge.rs
@@ -289,13 +289,6 @@ pub fn in_place<T: Ord>(elements: &mut [T]) {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::assertions_on_result_states,
-    clippy::indexing_slicing
-)]
 mod test {
     use super::*;
 

--- a/src/algorithm/sort/misc.rs
+++ b/src/algorithm/sort/misc.rs
@@ -65,13 +65,6 @@ pub fn cycle<T: Ord>(elements: &mut [T]) {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::assertions_on_result_states,
-    clippy::indexing_slicing
-)]
 mod test {
     use super::*;
 

--- a/src/algorithm/sort/quick.rs
+++ b/src/algorithm/sort/quick.rs
@@ -328,13 +328,6 @@ pub fn three_way<T: Ord>(elements: &mut [T]) {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::assertions_on_result_states,
-    clippy::indexing_slicing
-)]
 mod test {
     use super::*;
 

--- a/src/algorithm/sort/selection.rs
+++ b/src/algorithm/sort/selection.rs
@@ -299,13 +299,6 @@ pub fn bingo<T: Ord>(elements: &mut [T]) {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::assertions_on_result_states,
-    clippy::indexing_slicing
-)]
 mod test {
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,6 @@
         clippy::unwrap_used,
         clippy::expect_used,
 
-        // TODO: struggling to justify this one
-        // clippy::assertions_on_result_states,
-
         // Indexing/slicing inside tests ought to be so obviously within bounds
         // that requiring use of `get` and then unwrapping the result would be
         // unnecessarily verbose. To the extent that invalid bounds may still

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,32 @@
 //! Hand-written implementations in Rust for personal reference.
 
-// Disable particularly aggressive lints exclusively for tests.
+// Disable counter-productive lints within tests.
 #![cfg_attr(
     test,
     allow(
+        // Unsafe code inside tests ought to be so obviously safe such that
+        // requiring an explanation would be unnecessarily verbose. To the
+        // extent that safety may be genuinely violated without sufficient
+        // explanation, it either does not matter within the context of testing
+        // since that code will never be ran in production, and/or the testing
+        // itself (most likely dynamic analysis via Miri) will catch it.
         clippy::undocumented_unsafe_blocks,
+
+        // A wrapper failing to contain a value that is expected to exist
+        // implies the failure of that test which panicking invokes. Since
+        // use of this feature is allowed only within tests, the potential
+        // unrecoverable error is the explicit purpose of using it.
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::assertions_on_result_states,
+
+        // TODO: struggling to justify this one
+        // clippy::assertions_on_result_states,
+
+        // Indexing/slicing inside tests ought to be so obviously within bounds
+        // that requiring use of `get` and then unwrapping the result would be
+        // unnecessarily verbose. To the extent that invalid bounds may still
+        // be used, that code will never be ran in production and it will
+        // invoke a panic thusly failing that test until corrected.
         clippy::indexing_slicing
     )
 )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@
         // implies the failure of that test which panicking invokes. Since
         // use of this feature is allowed only within tests, the potential
         // unrecoverable error is the explicit purpose of using it.
-        clippy::unwrap_used,
         clippy::expect_used,
 
         // Indexing/slicing inside tests ought to be so obviously within bounds

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,16 @@
 //! Hand-written implementations in Rust for personal reference.
 
+// Disable particularly aggressive lints exclusively for tests.
+#![cfg_attr(
+    test,
+    allow(
+        clippy::undocumented_unsafe_blocks,
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::assertions_on_result_states,
+        clippy::indexing_slicing
+    )
+)]
+
 pub mod algorithm;
 pub mod structure;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,10 @@
         // unrecoverable error is the explicit purpose of using it.
         clippy::expect_used,
 
-        // Indexing/slicing inside tests ought to be so obviously within bounds
-        // that requiring use of `get` and then unwrapping the result would be
-        // unnecessarily verbose. To the extent that invalid bounds may still
-        // be used, that code will never be ran in production and it will
-        // invoke a panic thusly failing that test until corrected.
+        // An index being out of expected bounds implies the failure of that
+        // test which panicking invokes. Since use of this feature is allowed
+        // only within tests, the potential unrecoverable error is the explicit
+        // purpose of using it.
         clippy::indexing_slicing
     )
 )]

--- a/src/structure/collection/linear/array/dope.rs
+++ b/src/structure/collection/linear/array/dope.rs
@@ -362,11 +362,6 @@ impl<'a, T: 'a> Array for Dope<'a, T> {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used
-)]
 mod test {
     use super::*;
 

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -2783,7 +2783,7 @@ mod test {
 
             #[test]
             fn zero_size_types_cannot_fail() {
-                let capacity = usize::try_from(isize::MAX).unwrap();
+                let capacity = usize::try_from(isize::MAX).expect("usize::MAX > isize::MAX");
 
                 let _actual = Dynamic::<()>::with_capacity(capacity).expect("ZSTs do not occupy memory");
             }
@@ -2950,7 +2950,7 @@ mod test {
 
                     _ = actual.reserve(capacity).expect("successful allocation");
 
-                    let capacity = capacity.checked_next_power_of_two().unwrap();
+                    let capacity = capacity.checked_next_power_of_two().expect("loop conditions ensures this will fit");
 
                     assert_eq!(actual.capacity(), capacity);
                 }
@@ -3039,7 +3039,7 @@ mod test {
 
             #[test]
             fn zero_size_types_cannot_fail() {
-                let capacity = usize::try_from(isize::MAX).unwrap();
+                let capacity = usize::try_from(isize::MAX).expect("usize::MAX > isize::MAX");
 
                 let mut actual = Dynamic::<()>::default();
 
@@ -3140,7 +3140,7 @@ mod test {
 
             #[test]
             fn zero_size_types_cannot_fail() {
-                let capacity = usize::try_from(isize::MAX).unwrap();
+                let capacity = usize::try_from(isize::MAX).expect("usize::MAX > isize::MAX");
 
                 let mut actual = Dynamic::<()>::default();
 
@@ -3241,7 +3241,7 @@ mod test {
 
             #[test]
             fn zero_size_types_cannot_fail() {
-                let capacity = usize::try_from(isize::MAX).unwrap();
+                let capacity = usize::try_from(isize::MAX).expect("usize::MAX > isize::MAX");
 
                 let mut actual = Dynamic::<()>::default();
 
@@ -3361,7 +3361,7 @@ mod test {
 
             #[test]
             fn zero_size_types_cannot_fail() {
-                let capacity = usize::try_from(isize::MAX).unwrap();
+                let capacity = usize::try_from(isize::MAX).expect("usize::MAX > isize::MAX");
 
                 let mut actual = Dynamic::<()>::with_capacity(capacity).expect("successful allocation");
 
@@ -3476,7 +3476,7 @@ mod test {
 
             #[test]
             fn zero_size_types_cannot_fail() {
-                let capacity = usize::try_from(isize::MAX).unwrap();
+                let capacity = usize::try_from(isize::MAX).expect("usize::MAX > isize::MAX");
 
                 let mut actual = Dynamic::<()>::with_capacity(capacity).expect("successful allocation");
 
@@ -3591,7 +3591,7 @@ mod test {
 
             #[test]
             fn zero_size_types_cannot_fail() {
-                let capacity = usize::try_from(isize::MAX).unwrap();
+                let capacity = usize::try_from(isize::MAX).expect("usize::MAX > isize::MAX");
 
                 let mut actual = Dynamic::<()>::with_capacity(capacity).expect("successful allocation");
 
@@ -3888,7 +3888,7 @@ mod test {
                 let mut actual = Dynamic::from_iter([0, 1, 2, 3, 4, 5]);
 
                 for elements in 1..=actual.initialized {
-                    let elements = isize::try_from(elements).unwrap();
+                    let elements = isize::try_from(elements).expect("there are less than isize::MAX elements");
 
                     _ = actual.resize(-elements).expect_err("not enough capacity");
                 }

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -2725,13 +2725,6 @@ impl core::fmt::Display for OutOfBounds {
 impl core::error::Error for OutOfBounds {}
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::assertions_on_result_states,
-    clippy::indexing_slicing
-)]
 mod test {
     use super::*;
 

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -2778,18 +2778,14 @@ mod test {
 
             #[test]
             fn zero_capacity_cannot_fail() {
-                let actual = Dynamic::<usize>::with_capacity(0);
-
-                assert!(actual.is_ok());
+                let _actual = Dynamic::<usize>::with_capacity(0).expect("does no allocation");
             }
 
             #[test]
             fn zero_size_types_cannot_fail() {
                 let capacity = usize::try_from(isize::MAX).unwrap();
 
-                let actual = Dynamic::<()>::with_capacity(capacity);
-
-                assert!(actual.is_ok());
+                let _actual = Dynamic::<()>::with_capacity(capacity).expect("ZSTs do not occupy memory");
             }
         }
 
@@ -2965,7 +2961,8 @@ mod test {
                 let mut actual =
                     Dynamic::<usize>::with_capacity(256).expect("successful allocation");
 
-                assert!(actual.reserve(0).is_ok());
+                _ = actual.reserve(0).expect("does not alter allocation");
+
                 assert_eq!(actual.capacity(), 256);
             }
 
@@ -2977,7 +2974,7 @@ mod test {
 
                 let existing_allocation = actual.buffer.as_ptr();
 
-                assert!(actual.reserve(256).is_ok());
+                _ = actual.reserve(256).expect("does no reallocation");
 
                 assert_eq!(actual.buffer.as_ptr(), existing_allocation);
             }
@@ -3037,7 +3034,7 @@ mod test {
             fn zero_capacity_cannot_fail() {
                 let mut actual = Dynamic::<usize>::default();
 
-                assert!(actual.reserve(0).is_ok());
+                _ = actual.reserve(0).expect("does no allocation");
             }
 
             #[test]
@@ -3046,7 +3043,7 @@ mod test {
 
                 let mut actual = Dynamic::<()>::default();
 
-                assert!(actual.reserve(capacity).is_ok());
+                _ = actual.reserve(capacity).expect("ZSTs do not occupy memory");
             }
         }
 
@@ -3067,7 +3064,8 @@ mod test {
                 let mut actual =
                     Dynamic::<usize>::with_capacity(256).expect("successful allocation");
 
-                assert!(actual.reserve_front(0).is_ok());
+                _ = actual.reserve_front(0).expect("does not alter allocation");
+
                 assert_eq!(actual.capacity_front(), 256);
             }
 
@@ -3137,7 +3135,7 @@ mod test {
             fn zero_capacity_cannot_fail() {
                 let mut actual = Dynamic::<usize>::default();
 
-                assert!(actual.reserve_front(0).is_ok());
+                _ = actual.reserve_front(0).expect("does no allocation");
             }
 
             #[test]
@@ -3146,7 +3144,7 @@ mod test {
 
                 let mut actual = Dynamic::<()>::default();
 
-                assert!(actual.reserve_front(capacity).is_ok());
+                _ = actual.reserve_front(capacity).expect("ZSTs do not occupy memory");
             }
         }
 
@@ -3167,7 +3165,8 @@ mod test {
                 let mut actual =
                     Dynamic::<usize>::with_capacity(256).expect("successful allocation");
 
-                assert!(actual.reserve_back(0).is_ok());
+                _ = actual.reserve_back(0).expect("does not alter allocation");
+
                 assert_eq!(actual.capacity_back(), 256);
             }
 
@@ -3237,7 +3236,7 @@ mod test {
             fn zero_capacity_cannot_fail() {
                 let mut actual = Dynamic::<usize>::default();
 
-                assert!(actual.reserve_back(0).is_ok());
+                _ = actual.reserve_back(0).expect("does no allocation");
             }
 
             #[test]
@@ -3246,7 +3245,7 @@ mod test {
 
                 let mut actual = Dynamic::<()>::default();
 
-                assert!(actual.reserve_back(capacity).is_ok());
+                _ = actual.reserve_back(capacity).expect("ZSTs do not occupy memory");
             }
         }
 
@@ -3278,7 +3277,8 @@ mod test {
                 let mut actual =
                     Dynamic::<usize>::with_capacity(64).expect("successful allocation");
 
-                assert!(actual.shrink(Some(256)).is_ok());
+                _ = actual.shrink(Some(256)).expect("does not alter allocation");
+
                 assert_eq!(actual.capacity(), 64);
             }
 
@@ -3356,14 +3356,16 @@ mod test {
             fn zero_capacity_cannot_fail() {
                 let mut actual = Dynamic::<usize>::default();
 
-                assert!(actual.shrink(None).is_ok());
+                _ = actual.shrink(None).expect("does no allocation");
             }
 
             #[test]
             fn zero_size_types_cannot_fail() {
-                let mut actual = Dynamic::<()>::with_capacity(256).expect("successful allocation");
+                let capacity = usize::try_from(isize::MAX).unwrap();
 
-                assert!(actual.shrink(None).is_ok());
+                let mut actual = Dynamic::<()>::with_capacity(capacity).expect("successful allocation");
+
+                _ = actual.shrink(None).expect("ZSTs do not occupy memory");
             }
         }
 
@@ -3399,7 +3401,8 @@ mod test {
                 let mut actual =
                     Dynamic::<usize>::with_capacity(64).expect("successful allocation");
 
-                assert!(actual.shrink_front(Some(256)).is_ok());
+                _ = actual.shrink_front(Some(256)).expect("does not alter allocation");
+
                 assert_eq!(actual.capacity(), 64);
             }
 
@@ -3468,14 +3471,16 @@ mod test {
             fn zero_capacity_cannot_fail() {
                 let mut actual = Dynamic::<usize>::default();
 
-                assert!(actual.shrink_front(None).is_ok());
+                _ = actual.shrink_front(None).expect("does no allocation");
             }
 
             #[test]
             fn zero_size_types_cannot_fail() {
-                let mut actual = Dynamic::<()>::with_capacity(256).expect("successful allocation");
+                let capacity = usize::try_from(isize::MAX).unwrap();
 
-                assert!(actual.shrink_front(None).is_ok());
+                let mut actual = Dynamic::<()>::with_capacity(capacity).expect("successful allocation");
+
+                _ = actual.shrink_front(None).expect("ZSTs do not occupy memory");
             }
         }
 
@@ -3511,7 +3516,8 @@ mod test {
                 let mut actual =
                     Dynamic::<usize>::with_capacity(64).expect("successful allocation");
 
-                assert!(actual.shrink_back(Some(256)).is_ok());
+                _ = actual.shrink_back(Some(256)).expect("does not alter allocation");
+
                 assert_eq!(actual.capacity(), 64);
             }
 
@@ -3580,14 +3586,16 @@ mod test {
             fn zero_capacity_cannot_fail() {
                 let mut actual = Dynamic::<usize>::default();
 
-                assert!(actual.shrink_back(None).is_ok());
+                _ = actual.shrink_back(None).expect("does no allocation");
             }
 
             #[test]
             fn zero_size_types_cannot_fail() {
-                let mut actual = Dynamic::<()>::with_capacity(256).expect("successful allocation");
+                let capacity = usize::try_from(isize::MAX).unwrap();
 
-                assert!(actual.shrink_back(None).is_ok());
+                let mut actual = Dynamic::<()>::with_capacity(capacity).expect("successful allocation");
+
+                _ = actual.shrink_back(None).expect("ZSTs do not occupy memory");
             }
         }
 
@@ -3603,7 +3611,7 @@ mod test {
                     let front_capacity = actual.front_capacity;
                     let back_capacity = actual.back_capacity;
 
-                    assert!(actual.shift(-1).is_ok());
+                    _ = actual.shift(-1).expect("front capacity to shift into");
 
                     assert_eq!(actual.front_capacity, front_capacity - 1);
                     assert_eq!(actual.back_capacity, back_capacity + 1);
@@ -3617,7 +3625,7 @@ mod test {
                 _ = actual.reserve_front(256).expect("successful allocation");
 
                 for _ in 0..256 {
-                    assert!(actual.shift(-1).is_ok());
+                    _ = actual.shift(-1).expect("front capacity to shift into");
 
                     assert!(actual.iter().eq(expected.iter()));
                 }
@@ -3632,7 +3640,7 @@ mod test {
                     let front_capacity = actual.front_capacity;
                     let back_capacity = actual.back_capacity;
 
-                    assert!(actual.shift(1).is_ok());
+                    _ = actual.shift(1).expect("back capacity to shift into");
 
                     assert_eq!(actual.front_capacity, front_capacity + 1);
                     assert_eq!(actual.back_capacity, back_capacity - 1);
@@ -3646,7 +3654,7 @@ mod test {
                 _ = actual.reserve_back(256).expect("successful allocation");
 
                 for _ in 0..256 {
-                    assert!(actual.shift(1).is_ok());
+                    _ = actual.shift(1).expect("right capacity to shift into");
 
                     assert!(actual.iter().eq(expected.iter()));
                 }
@@ -3656,22 +3664,22 @@ mod test {
             fn zero_cannot_fail() {
                 let mut actual = Dynamic::from_iter([0, 1, 2, 3, 4, 5]);
 
-                assert!(actual.shift(0).is_ok());
+                _ = actual.shift(0).expect("does not alter allocation");
             }
 
             #[test]
             fn errors_when_out_of_bounds() {
                 let mut actual = Dynamic::from_iter([0, 1, 2, 3, 4, 5]);
 
-                assert!(actual.shift(-1).is_err());
-                assert!(actual.shift(1).is_err());
+                _ = actual.shift(-1).expect_err("no front capacity");
+                _ = actual.shift(1).expect_err("no back capacity");
             }
 
             #[test]
             fn when_empty() {
                 let mut actual = Dynamic::<()>::default();
 
-                assert!(actual.shift(0).is_ok());
+                _ = actual.shift(0).expect("does not alter allocation");
             }
         }
 
@@ -3882,7 +3890,7 @@ mod test {
                 for elements in 1..=actual.initialized {
                     let elements = isize::try_from(elements).unwrap();
 
-                    assert!(actual.resize(-elements).is_err());
+                    _ = actual.resize(-elements).expect_err("not enough capacity");
                 }
             }
 
@@ -3931,15 +3939,15 @@ mod test {
             fn zero_capacity_cannot_fail() {
                 let mut actual = Dynamic::<usize>::default();
 
-                assert!(actual.resize(0).is_ok());
+                _ = actual.resize(0).expect("does not alter allocation");
             }
 
             #[test]
             fn zero_size_types_cannot_fail() {
-                let mut actual = Dynamic::<()>::with_capacity(256).expect("successful allocation");
+                let mut actual = Dynamic::<()>::default();
 
-                assert!(actual.resize(128).is_ok());
-                assert!(actual.resize(-128).is_ok());
+                _ = actual.resize(isize::MAX).expect("ZSTs do not occupy memory");
+                _ = actual.resize(-isize::MAX).expect("ZSTs do not occupy memory");
             }
         }
     }
@@ -5026,7 +5034,7 @@ mod test {
             fn will_allocate_when_empty() {
                 let mut actual = Dynamic::<usize>::default();
 
-                assert!(actual.insert(0, 12345).is_ok());
+                _ = actual.insert(0, 12345).expect("successful allocation");
             }
 
             #[test]
@@ -5035,7 +5043,7 @@ mod test {
                 let mut actual: Dynamic<_> = expected.iter().copied().collect();
                 _ = actual.shrink(None).expect("no capacity");
 
-                assert!(actual.insert(2, 12345).is_ok());
+                _ = actual.insert(2, 12345).expect("successful allocation");
             }
 
             #[test]
@@ -5067,10 +5075,10 @@ mod test {
             }
 
             #[test]
-            fn can_prepend() {
+            fn prepending_reallocates_when_no_capacity() {
                 let mut actual = Dynamic::from_iter([0, 1, 2, 3, 4, 5]);
 
-                assert!(actual.insert(0, 12345).is_ok());
+                _ = actual.insert(0, 12345).expect("successful allocation");
             }
 
             #[test]
@@ -5094,10 +5102,10 @@ mod test {
             }
 
             #[test]
-            fn can_append() {
+            fn appending_reallocates_when_no_capacity() {
                 let mut actual = Dynamic::from_iter([0, 1, 2, 3, 4, 5]);
 
-                assert!(actual.insert(6, 12345).is_ok());
+                _ = actual.insert(6, 12345).expect("successful allocation");
             }
 
             #[test]
@@ -5707,7 +5715,8 @@ mod test {
             fn when_empty() {
                 let mut actual = Dynamic::<usize>::default();
 
-                assert!(actual.push(0).is_ok());
+                _ = actual.push(0).expect("successful allocation");
+
                 assert!(actual.eq([0]));
             }
         }
@@ -5836,7 +5845,8 @@ mod test {
             fn when_empty() {
                 let mut actual = Dynamic::<usize>::default();
 
-                assert!(actual.push(0).is_ok());
+                _ = actual.push(0).expect("successful allocation");
+
                 assert!(actual.eq([0]));
             }
         }

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -2785,7 +2785,8 @@ mod test {
             fn zero_size_types_cannot_fail() {
                 let capacity = usize::try_from(isize::MAX).expect("usize::MAX > isize::MAX");
 
-                let _actual = Dynamic::<()>::with_capacity(capacity).expect("ZSTs do not occupy memory");
+                let _actual =
+                    Dynamic::<()>::with_capacity(capacity).expect("ZSTs do not occupy memory");
             }
         }
 
@@ -2950,7 +2951,9 @@ mod test {
 
                     _ = actual.reserve(capacity).expect("successful allocation");
 
-                    let capacity = capacity.checked_next_power_of_two().expect("loop conditions ensures this will fit");
+                    let capacity = capacity
+                        .checked_next_power_of_two()
+                        .expect("loop conditions ensures this will fit");
 
                     assert_eq!(actual.capacity(), capacity);
                 }
@@ -3144,7 +3147,9 @@ mod test {
 
                 let mut actual = Dynamic::<()>::default();
 
-                _ = actual.reserve_front(capacity).expect("ZSTs do not occupy memory");
+                _ = actual
+                    .reserve_front(capacity)
+                    .expect("ZSTs do not occupy memory");
             }
         }
 
@@ -3245,7 +3250,9 @@ mod test {
 
                 let mut actual = Dynamic::<()>::default();
 
-                _ = actual.reserve_back(capacity).expect("ZSTs do not occupy memory");
+                _ = actual
+                    .reserve_back(capacity)
+                    .expect("ZSTs do not occupy memory");
             }
         }
 
@@ -3363,7 +3370,8 @@ mod test {
             fn zero_size_types_cannot_fail() {
                 let capacity = usize::try_from(isize::MAX).expect("usize::MAX > isize::MAX");
 
-                let mut actual = Dynamic::<()>::with_capacity(capacity).expect("successful allocation");
+                let mut actual =
+                    Dynamic::<()>::with_capacity(capacity).expect("successful allocation");
 
                 _ = actual.shrink(None).expect("ZSTs do not occupy memory");
             }
@@ -3401,7 +3409,9 @@ mod test {
                 let mut actual =
                     Dynamic::<usize>::with_capacity(64).expect("successful allocation");
 
-                _ = actual.shrink_front(Some(256)).expect("does not alter allocation");
+                _ = actual
+                    .shrink_front(Some(256))
+                    .expect("does not alter allocation");
 
                 assert_eq!(actual.capacity(), 64);
             }
@@ -3478,9 +3488,12 @@ mod test {
             fn zero_size_types_cannot_fail() {
                 let capacity = usize::try_from(isize::MAX).expect("usize::MAX > isize::MAX");
 
-                let mut actual = Dynamic::<()>::with_capacity(capacity).expect("successful allocation");
+                let mut actual =
+                    Dynamic::<()>::with_capacity(capacity).expect("successful allocation");
 
-                _ = actual.shrink_front(None).expect("ZSTs do not occupy memory");
+                _ = actual
+                    .shrink_front(None)
+                    .expect("ZSTs do not occupy memory");
             }
         }
 
@@ -3516,7 +3529,9 @@ mod test {
                 let mut actual =
                     Dynamic::<usize>::with_capacity(64).expect("successful allocation");
 
-                _ = actual.shrink_back(Some(256)).expect("does not alter allocation");
+                _ = actual
+                    .shrink_back(Some(256))
+                    .expect("does not alter allocation");
 
                 assert_eq!(actual.capacity(), 64);
             }
@@ -3593,7 +3608,8 @@ mod test {
             fn zero_size_types_cannot_fail() {
                 let capacity = usize::try_from(isize::MAX).expect("usize::MAX > isize::MAX");
 
-                let mut actual = Dynamic::<()>::with_capacity(capacity).expect("successful allocation");
+                let mut actual =
+                    Dynamic::<()>::with_capacity(capacity).expect("successful allocation");
 
                 _ = actual.shrink_back(None).expect("ZSTs do not occupy memory");
             }
@@ -3888,7 +3904,8 @@ mod test {
                 let mut actual = Dynamic::from_iter([0, 1, 2, 3, 4, 5]);
 
                 for elements in 1..=actual.initialized {
-                    let elements = isize::try_from(elements).expect("there are less than isize::MAX elements");
+                    let elements =
+                        isize::try_from(elements).expect("there are less than isize::MAX elements");
 
                     _ = actual.resize(-elements).expect_err("not enough capacity");
                 }
@@ -3946,8 +3963,12 @@ mod test {
             fn zero_size_types_cannot_fail() {
                 let mut actual = Dynamic::<()>::default();
 
-                _ = actual.resize(isize::MAX).expect("ZSTs do not occupy memory");
-                _ = actual.resize(-isize::MAX).expect("ZSTs do not occupy memory");
+                _ = actual
+                    .resize(isize::MAX)
+                    .expect("ZSTs do not occupy memory");
+                _ = actual
+                    .resize(-isize::MAX)
+                    .expect("ZSTs do not occupy memory");
             }
         }
     }

--- a/src/structure/collection/linear/array/fixed.rs
+++ b/src/structure/collection/linear/array/fixed.rs
@@ -539,11 +539,6 @@ impl<T, const N: usize> ExactSizeIterator for IntoIter<T, N> {}
 impl<T, const N: usize> core::iter::FusedIterator for IntoIter<T, N> {}
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used
-)]
 mod test {
     use super::*;
 

--- a/src/structure/collection/linear/array/iter/immutable.rs
+++ b/src/structure/collection/linear/array/iter/immutable.rs
@@ -115,11 +115,6 @@ impl<'a, T: 'a + core::fmt::Debug> core::fmt::Debug for Iter<'a, T> {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used
-)]
 mod test {
     use super::*;
 

--- a/src/structure/collection/linear/array/iter/mutable.rs
+++ b/src/structure/collection/linear/array/iter/mutable.rs
@@ -115,11 +115,6 @@ impl<'a, T: 'a + core::fmt::Debug> core::fmt::Debug for IterMut<'a, T> {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used
-)]
 mod test {
     use super::*;
 

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -2992,7 +2992,8 @@ mod test {
             fn when_empty() {
                 let mut actual = Doubly::<usize>::default();
 
-                assert!(actual.insert(0, 12345).is_ok());
+                _ = actual.insert(0, 12345).expect("successful allocation");
+
                 assert_eq!(actual.head, actual.tail);
                 assert!(actual.eq([12345]));
             }
@@ -3125,7 +3126,8 @@ mod test {
             fn when_empty() {
                 let mut actual = Doubly::<usize>::default();
 
-                assert!(actual.prepend(0).is_ok());
+                _ = actual.prepend(0).expect("successful allocation");
+
                 assert_eq!(actual.head, actual.tail);
                 assert!(actual.eq([0]));
             }
@@ -3179,7 +3181,8 @@ mod test {
             fn when_empty() {
                 let mut actual = Doubly::<usize>::default();
 
-                assert!(actual.append(0).is_ok());
+                _ = actual.append(0).expect("successful allocation");
+
                 assert_eq!(actual.head, actual.tail);
                 assert!(actual.eq([0]));
             }
@@ -3645,7 +3648,8 @@ mod test {
             fn when_empty() {
                 let mut actual = Doubly::<usize>::default();
 
-                assert!(actual.push(0).is_ok());
+                _ = actual.push(0).expect("successful allocation");
+
                 assert!(actual.eq([0]));
             }
         }
@@ -3775,7 +3779,8 @@ mod test {
             fn when_empty() {
                 let mut actual = Doubly::<usize>::default();
 
-                assert!(actual.push(0).is_ok());
+                _ = actual.push(0).expect("successful allocation");
+
                 assert!(actual.eq([0]));
             }
         }

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -1999,13 +1999,6 @@ impl<T, F: FnMut(&T) -> bool> ExactSizeIterator for Withdraw<'_, T, F> {}
 impl<T, F: FnMut(&T) -> bool> core::iter::FusedIterator for Withdraw<'_, T, F> {}
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::assertions_on_result_states,
-    clippy::indexing_slicing
-)]
 mod test {
     use super::*;
 

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -2676,7 +2676,7 @@ mod test {
             fn when_empty() {
                 let mut actual = Singly::<usize>::default();
 
-                assert!(actual.insert(0, 12345).is_ok());
+                _ = actual.insert(0, 12345).expect("successful allocation");
             }
 
             #[test]
@@ -2807,7 +2807,8 @@ mod test {
             fn when_empty() {
                 let mut actual = Singly::<usize>::default();
 
-                assert!(actual.prepend(0).is_ok());
+                _ = actual.prepend(0).expect("successful allocation");
+
                 assert!(actual.eq([0]));
             }
         }
@@ -2860,7 +2861,8 @@ mod test {
             fn when_empty() {
                 let mut actual = Singly::<usize>::default();
 
-                assert!(actual.append(0).is_ok());
+                _ = actual.append(0).expect("successful allocation");
+
                 assert!(actual.eq([0]));
             }
         }
@@ -3346,7 +3348,8 @@ mod test {
             fn when_empty() {
                 let mut actual = Singly::<usize>::default();
 
-                assert!(actual.push(0).is_ok());
+                _ = actual.push(0).expect("successful allocation");
+
                 assert!(actual.eq([0]));
             }
         }
@@ -3475,7 +3478,8 @@ mod test {
             fn when_empty() {
                 let mut actual = Singly::<usize>::default();
 
-                assert!(actual.push(0).is_ok());
+                _ = actual.push(0).expect("successful allocation");
+
                 assert!(actual.eq([0]));
             }
         }

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -1684,13 +1684,6 @@ impl<T, F: FnMut(&T) -> bool> ExactSizeIterator for Withdraw<'_, T, F> {}
 impl<T, F: FnMut(&T) -> bool> core::iter::FusedIterator for Withdraw<'_, T, F> {}
 
 #[cfg(test)]
-#[allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::assertions_on_result_states,
-    clippy::indexing_slicing
-)]
 mod test {
     use super::*;
 


### PR DESCRIPTION
### Description

Closes #109 

### Checklist

#### Documentation

- [x] Public **and** private symbols described?
- [x] Performance considerations for all subroutines?
  - [x] Time complexity?
  - [x] Memory complexity?
- [x] Examples for public interfaces?
  - [x] `cargo test --doc` passes?
- [x] `cargo doc --document-private-items` passes?

#### Testing

- [x] All post-conditions tested?
- [x] Dedicated tests for edge-cases?
- [x] Naming consistent with the existing codebase?
- [x] Organized into a module hierarchy?
- [x] `cargo test --tests` passes?
- [x] `MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo +nightly miri test` passes?

#### Style

- [x] Considered [exception safety](https://doc.rust-lang.org/nomicon/exception-safety.html)?
- [x] `cargo check` passes?
- [x] `cargo clippy` passes?
- [x] `cargo fmt` passes?

#### Chores

- [x] Bumped version?
- [x] Added link to readme?
- [x] Rebased branch for clean commit history?
