### PR TITLE
consistent owning iterator tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "rust"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 
 authors = ["Tyler St. Onge <tyler@stonge.dev>"]

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -5457,6 +5457,20 @@ mod test {
 
                         assert!(actual.drain(1..4).rev().eq(expected.drain(1..4).rev()));
                     }
+
+                    #[test]
+                    fn prevents_elements_from_being_yielded_more_than_once() {
+                        let mut underlying = Dynamic::from_iter([0, 1, 2, 0]);
+
+                        let mut actual = underlying.drain(1..=2);
+
+                        // make head and tail meet.
+                        _ = actual.next().expect("the element with value '1'");
+                        _ = actual.next_back().expect("the element with value '2'");
+
+                        assert_eq!(actual.next(), None);
+                        assert_eq!(actual.next_back(), None);
+                    }
                 }
 
                 mod exact_size {

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -5409,7 +5409,7 @@ mod test {
             fn none_when_out_of_bounds_range() {
                 let mut instance = Dynamic::from_iter([0, 1, 2, 3, 4, 5]);
 
-                let mut actual = instance.drain(256..);
+                let mut actual = instance.drain(6..);
 
                 assert_eq!(actual.next(), None);
                 assert_eq!(actual.next_back(), None);

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -4162,6 +4162,7 @@ mod test {
             #[test]
             fn element_count() {
                 let expected = [0, 1, 2, 3, 4, 5];
+
                 let actual: Dynamic<_> = expected.iter().copied().collect();
 
                 assert_eq!(actual.into_iter().count(), expected.len());
@@ -4170,6 +4171,7 @@ mod test {
             #[test]
             fn in_order() {
                 let expected = [0, 1, 2, 3, 4, 5];
+
                 let actual: Dynamic<_> = expected.iter().copied().collect();
 
                 assert!(actual.into_iter().eq(expected.into_iter()));

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -5504,7 +5504,7 @@ mod test {
                     #[test]
                     fn empty() {
                         let mut actual = Dynamic::<()>::default();
-                        let mut actual = actual.drain(0..=0);
+                        let mut actual = actual.drain(..);
 
                         // Yields `None` at least once.
                         assert_eq!(actual.next(), None);
@@ -5518,7 +5518,7 @@ mod test {
                     #[test]
                     fn exhausted() {
                         let mut actual: Dynamic<_> = [()].into_iter().collect();
-                        let mut actual = actual.drain(0..=0);
+                        let mut actual = actual.drain(..);
 
                         // Exhaust the elements.
                         let _: () = actual.next().expect("the one element");

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -2170,7 +2170,7 @@ impl<T> Drop for Drain<'_, T> {
             let only_back_capacity =
                 self.underlying.front_capacity == 0 && self.underlying.back_capacity != 0;
 
-            if only_front_capacity || (!only_back_capacity && leading > trailing) {
+            if only_front_capacity || (!only_back_capacity && trailing > leading) {
                 // SAFETY: [front capacity] [shift] [drained] [remain] [back capacity]
                 unsafe {
                     self.underlying.shift_range(0..self.range.start, offset);

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -2176,7 +2176,8 @@ impl<T> Drop for Drain<'_, T> {
                     self.underlying.shift_range(0..self.range.start, offset);
                 }
 
-                let Some(capacity) = self.underlying.front_capacity.checked_add(self.range.len()) else {
+                let Some(capacity) = self.underlying.front_capacity.checked_add(self.range.len())
+                else {
                     unreachable!("allocated more than `isize::MAX` bytes");
                 };
 
@@ -2187,9 +2188,13 @@ impl<T> Drop for Drain<'_, T> {
                 };
 
                 // SAFETY: [front capacity] [remain] [drained] [shift] [back capacity]
-                unsafe { self.underlying.shift_range(self.range.end..self.underlying.initialized, offset); }
+                unsafe {
+                    self.underlying
+                        .shift_range(self.range.end..self.underlying.initialized, offset);
+                }
 
-                let Some(capacity) = self.underlying.back_capacity.checked_add(self.range.len()) else {
+                let Some(capacity) = self.underlying.back_capacity.checked_add(self.range.len())
+                else {
                     unreachable!("allocated more than `isize::MAX` bytes");
                 };
 
@@ -4191,10 +4196,15 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
-                        let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        })).into_iter();
+                        #[expect(
+                            clippy::useless_conversion,
+                            reason = "explicitly testing into iterator"
+                        )]
+                        let mut actual =
+                            Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }))
+                            .into_iter();
 
                         for _ in 0..yielded {
                             // Lifetime is passed to caller.
@@ -4222,10 +4232,15 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
-                        let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        })).into_iter();
+                        #[expect(
+                            clippy::useless_conversion,
+                            reason = "explicitly testing into iterator"
+                        )]
+                        let mut actual =
+                            Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }))
+                            .into_iter();
 
                         for _ in 0..yielded {
                             // Lifetime is passed to caller.
@@ -4254,10 +4269,15 @@ mod test {
                         for back in front..ELEMENTS {
                             let dropped = DropCounter::new_counter();
 
-                            #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
-                            let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                                DropCounter::new(&dropped)
-                            })).into_iter();
+                            #[expect(
+                                clippy::useless_conversion,
+                                reason = "explicitly testing into iterator"
+                            )]
+                            let mut actual =
+                                Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                    DropCounter::new(&dropped)
+                                }))
+                                .into_iter();
 
                             for _ in 0..front {
                                 // Lifetime is passed to caller.
@@ -5578,9 +5598,10 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        }));
+                        let mut actual =
+                            Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }));
 
                         let mut actual = actual.drain(..);
 
@@ -5610,9 +5631,10 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        }));
+                        let mut actual =
+                            Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }));
 
                         let mut actual = actual.drain(..);
 
@@ -5643,9 +5665,10 @@ mod test {
                         for back in front..ELEMENTS {
                             let dropped = DropCounter::new_counter();
 
-                            let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                                DropCounter::new(&dropped)
-                            }));
+                            let mut actual =
+                                Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                    DropCounter::new(&dropped)
+                                }));
 
                             let mut actual = actual.drain(..);
 
@@ -5773,7 +5796,9 @@ mod test {
                         let mut actual: Dynamic<_> = expected.iter().copied().collect();
 
                         // Add front capacity.
-                        _ = actual.reserve_front(ELEMENTS).expect("successful allocation");
+                        _ = actual
+                            .reserve_front(ELEMENTS)
+                            .expect("successful allocation");
                         debug_assert_eq!(actual.back_capacity, 0);
 
                         let removed = start..(ELEMENTS - 1);
@@ -5794,7 +5819,9 @@ mod test {
                         let mut actual: Dynamic<_> = expected.iter().copied().collect();
 
                         // Add front capacity.
-                        _ = actual.reserve_back(ELEMENTS).expect("successful allocation");
+                        _ = actual
+                            .reserve_back(ELEMENTS)
+                            .expect("successful allocation");
                         debug_assert_eq!(actual.front_capacity, 0);
 
                         let removed = start..(ELEMENTS - 1);
@@ -5806,7 +5833,8 @@ mod test {
                 }
 
                 #[test]
-                fn increases_front_capacity_when_front_and_back_capacity_but_more_trailing_elements() {
+                fn increases_front_capacity_when_front_and_back_capacity_but_more_trailing_elements()
+                 {
                     const ELEMENTS: usize = 8;
 
                     let expected = core::array::from_fn::<_, ELEMENTS, _>(|index| index);
@@ -5814,8 +5842,12 @@ mod test {
                     for start in 1..(ELEMENTS / 2) {
                         let mut actual: Dynamic<_> = expected.iter().copied().collect();
 
-                        _ = actual.reserve_front(ELEMENTS).expect("successful allocation");
-                        _ = actual.reserve_back(ELEMENTS).expect("successful allocation");
+                        _ = actual
+                            .reserve_front(ELEMENTS)
+                            .expect("successful allocation");
+                        _ = actual
+                            .reserve_back(ELEMENTS)
+                            .expect("successful allocation");
 
                         let removed = start..(ELEMENTS / 2);
 
@@ -5826,7 +5858,8 @@ mod test {
                 }
 
                 #[test]
-                fn increases_back_capacity_when_front_and_back_capacity_but_more_leading_elements() {
+                fn increases_back_capacity_when_front_and_back_capacity_but_more_leading_elements()
+                {
                     const ELEMENTS: usize = 8;
 
                     let expected = core::array::from_fn::<_, ELEMENTS, _>(|index| index);
@@ -5834,8 +5867,12 @@ mod test {
                     for start in (ELEMENTS / 2)..ELEMENTS {
                         let mut actual: Dynamic<_> = expected.iter().copied().collect();
 
-                        _ = actual.reserve_front(ELEMENTS).expect("successful allocation");
-                        _ = actual.reserve_back(ELEMENTS).expect("successful allocation");
+                        _ = actual
+                            .reserve_front(ELEMENTS)
+                            .expect("successful allocation");
+                        _ = actual
+                            .reserve_back(ELEMENTS)
+                            .expect("successful allocation");
 
                         let removed = start..(ELEMENTS / 2);
 
@@ -5993,9 +6030,10 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        }));
+                        let mut actual =
+                            Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }));
 
                         let mut actual = actual.withdraw(|_| true);
 
@@ -6025,9 +6063,10 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        }));
+                        let mut actual =
+                            Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }));
 
                         let mut actual = actual.withdraw(|_| true);
 
@@ -6058,9 +6097,10 @@ mod test {
                         for back in front..ELEMENTS {
                             let dropped = DropCounter::new_counter();
 
-                            let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                                DropCounter::new(&dropped)
-                            }));
+                            let mut actual =
+                                Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                    DropCounter::new(&dropped)
+                                }));
 
                             let mut actual = actual.withdraw(|_| true);
 
@@ -6110,7 +6150,10 @@ mod test {
                     const ELEMENTS: usize = 8;
 
                     for count in 0..=ELEMENTS {
-                        let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|index| index));
+                        let mut actual =
+                            Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|index| {
+                                index
+                            }));
                         debug_assert_eq!(actual.capacity(), 0);
 
                         drop(actual.withdraw(|element| element < &count));
@@ -6124,7 +6167,10 @@ mod test {
                     const ELEMENTS: usize = 8;
 
                     for retained in 0..ELEMENTS {
-                        let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|index| index));
+                        let mut actual =
+                            Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|index| {
+                                index
+                            }));
                         debug_assert_eq!(actual.front_capacity, 0);
                         debug_assert_eq!(actual.back_capacity, 0);
 
@@ -6156,7 +6202,7 @@ mod test {
                     // the underlying buffer for future use.
                     drop(iter);
 
-                    assert!(actual.eq([0 ,1 ,2, 5, 6, 7]));
+                    assert!(actual.eq([0, 1, 2, 5, 6, 7]));
                 }
             }
         }

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -5440,14 +5440,22 @@ mod test {
                 }
 
                 #[test]
-                fn yields_no_elements_when_range_is_out_of_bounds() {
+                fn yields_no_elements_when_start_of_range_is_out_of_bounds() {
                     let mut actual = Dynamic::from_iter([0, 1, 2, 3, 4, 5]);
 
                     let mut actual = actual.drain(6..);
 
                     assert_eq!(actual.next(), None);
+                    assert_eq!(actual.next_back(), None);
+                }
 
-                    drop(actual);
+                #[test]
+                fn yields_elements_when_end_of_range_is_out_of_bounds() {
+                    let mut actual = Dynamic::from_iter([0, 1, 2, 3, 4, 5]);
+
+                    let actual = actual.drain(..usize::MAX);
+
+                    assert!(actual.eq([0, 1, 2, 3, 4, 5]));
                 }
 
                 #[test]
@@ -5481,14 +5489,21 @@ mod test {
                     }
 
                     #[test]
-                    fn yields_no_elements_when_range_is_out_of_bounds() {
+                    fn yields_no_elements_when_start_of_range_is_out_of_bounds() {
                         let mut actual = Dynamic::from_iter([0, 1, 2, 3, 4, 5]);
 
                         let mut actual = actual.drain(6..);
 
                         assert_eq!(actual.next_back(), None);
+                    }
 
-                        drop(actual);
+                    #[test]
+                    fn yields_elements_when_end_of_range_is_out_of_bounds() {
+                        let mut actual = Dynamic::from_iter([0, 1, 2, 3, 4, 5]);
+
+                        let actual = actual.drain(..usize::MAX).rev();
+
+                        assert!(actual.eq([5, 4, 3, 2, 1, 0]));
                     }
 
                     #[test]

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -4226,6 +4226,37 @@ mod test {
 
                     assert!(actual.into_iter().rev().eq(expected.into_iter().rev()));
                 }
+
+                #[test]
+                fn drops_front_elements_yet_to_be_yielded() {
+                    use crate::test::mock::DropCounter;
+
+                    const ELEMENTS: usize = 256;
+
+                    for yielded in 0..ELEMENTS {
+                        let dropped = DropCounter::new_counter();
+
+                        #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
+                        let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                            DropCounter::new(&dropped)
+                        })).into_iter();
+
+                        for _ in 0..yielded {
+                            // Caller is responsible for this yielded lifetime.
+                            drop(actual.next_back());
+                        }
+
+                        // Reset the counter so we do not count elements that were
+                        // yielded and then manually dropped in the above loop.
+                        _ = dropped.replace(0);
+
+                        // Now we drop the iterator which should implicitly drop
+                        // all the elements that were not yielded.
+                        drop(actual);
+
+                        assert_eq!(dropped.take(), ELEMENTS - yielded);
+                    }
+                }
             }
 
             mod exact_size {

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -4177,6 +4177,37 @@ mod test {
                 assert!(actual.into_iter().eq(expected.into_iter()));
             }
 
+            #[test]
+            fn drops_back_elements_yet_to_be_yielded() {
+                use crate::test::mock::DropCounter;
+
+                const ELEMENTS: usize = 256;
+
+                for yielded in 0..ELEMENTS {
+                    let dropped = DropCounter::new_counter();
+
+                    #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
+                    let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                        DropCounter::new(&dropped)
+                    })).into_iter();
+
+                    for _ in 0..yielded {
+                        // Caller is responsible for this yielded lifetime.
+                        drop(actual.next());
+                    }
+
+                    // Reset the counter so we do not count elements that were
+                    // yielded and then manually dropped in the above loop.
+                    _ = dropped.replace(0);
+
+                    // Now we drop the iterator which should implicitly drop
+                    // all the elements that were not yielded.
+                    drop(actual);
+
+                    assert_eq!(dropped.take(), ELEMENTS - yielded);
+                }
+            }
+
             mod double_ended {
                 use super::*;
 

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -5417,6 +5417,18 @@ mod test {
                 drop(actual);
             }
 
+            #[test]
+            fn none_when_empty() {
+                let mut instance = Dynamic::<()>::default();
+
+                let mut actual = instance.drain(..);
+
+                assert_eq!(actual.next(), None);
+                assert_eq!(actual.next_back(), None);
+
+                drop(actual);
+            }
+
             mod iterator {
                 use super::*;
 

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -5406,7 +5406,7 @@ mod test {
             use super::*;
 
             #[test]
-            fn none_out_of_bounds_range() {
+            fn none_when_out_of_bounds_range() {
                 let mut instance = Dynamic::from_iter([0, 1, 2, 3, 4, 5]);
 
                 let mut actual = instance.drain(256..);

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -4177,58 +4177,42 @@ mod test {
                 assert!(actual.into_iter().eq(expected.into_iter()));
             }
 
-            #[test]
-            fn drops_back_elements_yet_to_be_yielded() {
-                use crate::test::mock::DropCounter;
-
-                const ELEMENTS: usize = 256;
-
-                for yielded in 0..ELEMENTS {
-                    let dropped = DropCounter::new_counter();
-
-                    #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
-                    let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                        DropCounter::new(&dropped)
-                    })).into_iter();
-
-                    for _ in 0..yielded {
-                        // Caller is responsible for this yielded lifetime.
-                        drop(actual.next());
-                    }
-
-                    // Reset the counter so we do not count elements that were
-                    // yielded and then manually dropped in the above loop.
-                    _ = dropped.replace(0);
-
-                    // Now we drop the iterator which should implicitly drop
-                    // all the elements that were not yielded.
-                    drop(actual);
-
-                    assert_eq!(dropped.take(), ELEMENTS - yielded);
-                }
-            }
-
-            mod double_ended {
+            mod drop {
                 use super::*;
 
                 #[test]
-                fn element_count() {
-                    let expected = [0, 1, 2, 3, 4, 5];
-                    let actual: Dynamic<_> = expected.iter().copied().collect();
+                fn drops_unyielded_elements_when_advanced_from_front() {
+                    use crate::test::mock::DropCounter;
 
-                    assert_eq!(actual.into_iter().rev().count(), expected.len());
+                    const ELEMENTS: usize = 256;
+
+                    for yielded in 0..ELEMENTS {
+                        let dropped = DropCounter::new_counter();
+
+                        #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
+                        let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                            DropCounter::new(&dropped)
+                        })).into_iter();
+
+                        for _ in 0..yielded {
+                            // Caller is responsible for this yielded lifetime.
+                            drop(actual.next());
+                        }
+
+                        // Reset the counter so we do not count elements that were
+                        // yielded and then manually dropped in the above loop.
+                        _ = dropped.replace(0);
+
+                        // Now we drop the iterator which should implicitly drop
+                        // all the elements that were not yielded.
+                        drop(actual);
+
+                        assert_eq!(dropped.take(), ELEMENTS - yielded);
+                    }
                 }
 
                 #[test]
-                fn in_order() {
-                    let expected = [0, 1, 2, 3, 4, 5];
-                    let actual: Dynamic<_> = expected.iter().copied().collect();
-
-                    assert!(actual.into_iter().rev().eq(expected.into_iter().rev()));
-                }
-
-                #[test]
-                fn drops_front_elements_yet_to_be_yielded() {
+                fn drops_unyielded_elements_when_advanced_from_back() {
                     use crate::test::mock::DropCounter;
 
                     const ELEMENTS: usize = 256;
@@ -4259,7 +4243,7 @@ mod test {
                 }
 
                 #[test]
-                fn drops_middle_elements_yet_to_be_yielded() {
+                fn drops_unyielded_elements_when_advanced_from_both_ends() {
                     use crate::test::mock::DropCounter;
 
                     const ELEMENTS: usize = 256;
@@ -4288,6 +4272,28 @@ mod test {
 
                         assert_eq!(dropped.take(), ELEMENTS - yielded);
                     }
+                }
+            }
+
+            mod double_ended {
+                use super::*;
+
+                #[test]
+                fn element_count() {
+                    let expected = [0, 1, 2, 3, 4, 5];
+
+                    let actual: Dynamic<_> = expected.iter().copied().collect();
+
+                    assert_eq!(actual.into_iter().rev().count(), expected.len());
+                }
+
+                #[test]
+                fn in_order() {
+                    let expected = [0, 1, 2, 3, 4, 5];
+
+                    let actual: Dynamic<_> = expected.iter().copied().collect();
+
+                    assert!(actual.into_iter().rev().eq(expected.into_iter().rev()));
                 }
             }
 

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -5514,7 +5514,7 @@ mod test {
                     use super::*;
 
                     #[test]
-                    fn empty() {
+                    fn when_empty() {
                         let mut actual = Dynamic::<()>::default();
                         let mut actual = actual.drain(..);
 
@@ -5528,7 +5528,7 @@ mod test {
                     }
 
                     #[test]
-                    fn exhausted() {
+                    fn when_exhausted() {
                         let mut actual: Dynamic<_> = [()].into_iter().collect();
                         let mut actual = actual.drain(..);
 

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -4184,7 +4184,7 @@ mod test {
                 fn drops_unyielded_elements_when_advanced_from_front() {
                     use crate::test::mock::DropCounter;
 
-                    const ELEMENTS: usize = 256;
+                    const ELEMENTS: usize = 8;
 
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
@@ -4195,16 +4195,16 @@ mod test {
                         })).into_iter();
 
                         for _ in 0..yielded {
-                            // Caller is responsible for this yielded lifetime.
+                            // Lifetime is passed to caller.
                             drop(actual.next());
                         }
 
-                        // Reset the counter so we do not count elements that were
-                        // yielded and then manually dropped in the above loop.
-                        _ = dropped.replace(0);
+                        // The above drops in caller scope, not the
+                        // destructor being tested, so reset counter.
+                        debug_assert_eq!(dropped.replace(0), yielded);
 
-                        // Now we drop the iterator which should implicitly drop
-                        // all the elements that were not yielded.
+                        // Now we drop the iterator, so we expect all
+                        // remaining elements to be dropped.
                         drop(actual);
 
                         assert_eq!(dropped.take(), ELEMENTS - yielded);
@@ -4215,7 +4215,7 @@ mod test {
                 fn drops_unyielded_elements_when_advanced_from_back() {
                     use crate::test::mock::DropCounter;
 
-                    const ELEMENTS: usize = 256;
+                    const ELEMENTS: usize = 8;
 
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
@@ -4226,16 +4226,16 @@ mod test {
                         })).into_iter();
 
                         for _ in 0..yielded {
-                            // Caller is responsible for this yielded lifetime.
+                            // Lifetime is passed to caller.
                             drop(actual.next_back());
                         }
 
-                        // Reset the counter so we do not count elements that were
-                        // yielded and then manually dropped in the above loop.
-                        _ = dropped.replace(0);
+                        // The above drops in caller scope, not the
+                        // destructor being tested, so reset counter.
+                        debug_assert_eq!(dropped.replace(0), yielded);
 
-                        // Now we drop the iterator which should implicitly drop
-                        // all the elements that were not yielded.
+                        // Now we drop the iterator, so we expect all
+                        // remaining elements to be dropped.
                         drop(actual);
 
                         assert_eq!(dropped.take(), ELEMENTS - yielded);
@@ -4246,31 +4246,37 @@ mod test {
                 fn drops_unyielded_elements_when_advanced_from_both_ends() {
                     use crate::test::mock::DropCounter;
 
-                    const ELEMENTS: usize = 256;
+                    const ELEMENTS: usize = 8;
 
-                    for yielded in (0..ELEMENTS).step_by(2) {
-                        let dropped = DropCounter::new_counter();
+                    for front in 0..ELEMENTS {
+                        for back in front..ELEMENTS {
+                            let dropped = DropCounter::new_counter();
 
-                        #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
-                        let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        })).into_iter();
+                            #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
+                            let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            })).into_iter();
 
-                        for _ in (0..yielded).step_by(2) {
-                            // Caller is responsible for these yielded lifetimes.
-                            drop(actual.next());
-                            drop(actual.next_back());
+                            for _ in 0..front {
+                                // Lifetime is passed to caller.
+                                drop(actual.next());
+                            }
+
+                            for _ in front..back {
+                                // Lifetime is passed to caller.
+                                drop(actual.next_back());
+                            }
+
+                            // The above drops in caller scope, not the
+                            // destructor being tested, so reset counter.
+                            let expected = ELEMENTS - dropped.replace(0);
+
+                            // Now we drop the iterator, so we expect all
+                            // remaining elements to be dropped.
+                            drop(actual);
+
+                            assert_eq!(dropped.take(), expected);
                         }
-
-                        // Reset the counter so we do not count elements that were
-                        // yielded and then manually dropped in the above loop.
-                        _ = dropped.replace(0);
-
-                        // Now we drop the iterator which should implicitly drop
-                        // all the elements that were not yielded.
-                        drop(actual);
-
-                        assert_eq!(dropped.take(), ELEMENTS - yielded);
                     }
                 }
             }

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -4257,6 +4257,38 @@ mod test {
                         assert_eq!(dropped.take(), ELEMENTS - yielded);
                     }
                 }
+
+                #[test]
+                fn drops_middle_elements_yet_to_be_yielded() {
+                    use crate::test::mock::DropCounter;
+
+                    const ELEMENTS: usize = 256;
+
+                    for yielded in (0..ELEMENTS).step_by(2) {
+                        let dropped = DropCounter::new_counter();
+
+                        #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
+                        let mut actual = Dynamic::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                            DropCounter::new(&dropped)
+                        })).into_iter();
+
+                        for _ in (0..yielded).step_by(2) {
+                            // Caller is responsible for these yielded lifetimes.
+                            drop(actual.next());
+                            drop(actual.next_back());
+                        }
+
+                        // Reset the counter so we do not count elements that were
+                        // yielded and then manually dropped in the above loop.
+                        _ = dropped.replace(0);
+
+                        // Now we drop the iterator which should implicitly drop
+                        // all the elements that were not yielded.
+                        drop(actual);
+
+                        assert_eq!(dropped.take(), ELEMENTS - yielded);
+                    }
+                }
             }
 
             mod exact_size {

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -5405,32 +5405,30 @@ mod test {
         mod drain {
             use super::*;
 
-            #[test]
-            fn none_when_out_of_bounds_range() {
-                let mut instance = Dynamic::from_iter([0, 1, 2, 3, 4, 5]);
-
-                let mut actual = instance.drain(6..);
-
-                assert_eq!(actual.next(), None);
-                assert_eq!(actual.next_back(), None);
-
-                drop(actual);
-            }
-
-            #[test]
-            fn none_when_empty() {
-                let mut instance = Dynamic::<()>::default();
-
-                let mut actual = instance.drain(..);
-
-                assert_eq!(actual.next(), None);
-                assert_eq!(actual.next_back(), None);
-
-                drop(actual);
-            }
-
             mod iterator {
                 use super::*;
+
+                #[test]
+                fn yields_no_elements_when_empty() {
+                    let mut actual = Dynamic::<()>::default();
+
+                    let mut actual = actual.drain(..);
+
+                    assert_eq!(actual.next(), None);
+
+                    drop(actual);
+                }
+
+                #[test]
+                fn yields_no_elements_when_range_is_out_of_bounds() {
+                    let mut actual = Dynamic::from_iter([0, 1, 2, 3, 4, 5]);
+
+                    let mut actual = actual.drain(6..);
+
+                    assert_eq!(actual.next(), None);
+
+                    drop(actual);
+                }
 
                 #[test]
                 fn element_count() {
@@ -5450,6 +5448,28 @@ mod test {
 
                 mod double_ended {
                     use super::*;
+
+                    #[test]
+                    fn yields_no_elements_when_empty() {
+                        let mut actual = Dynamic::<()>::default();
+
+                        let mut actual = actual.drain(..);
+
+                        assert_eq!(actual.next_back(), None);
+
+                        drop(actual);
+                    }
+
+                    #[test]
+                    fn yields_no_elements_when_range_is_out_of_bounds() {
+                        let mut actual = Dynamic::from_iter([0, 1, 2, 3, 4, 5]);
+
+                        let mut actual = actual.drain(6..);
+
+                        assert_eq!(actual.next_back(), None);
+
+                        drop(actual);
+                    }
 
                     #[test]
                     fn element_count() {

--- a/src/structure/collection/linear/array/fixed.rs
+++ b/src/structure/collection/linear/array/fixed.rs
@@ -609,6 +609,7 @@ mod test {
             #[test]
             fn element_count() {
                 let expected = [0, 1, 2, 3, 4, 5];
+
                 let actual = Fixed::from(expected);
 
                 assert_eq!(actual.into_iter().count(), expected.len());
@@ -617,6 +618,7 @@ mod test {
             #[test]
             fn in_order() {
                 let expected = [0, 1, 2, 3, 4, 5];
+
                 let actual = Fixed::from(expected);
 
                 assert!(actual.into_iter().eq(expected.into_iter()));
@@ -645,6 +647,7 @@ mod test {
                 #[test]
                 fn element_count() {
                     let expected = [0, 1, 2, 3, 4, 5];
+
                     let actual = Fixed::from(expected);
 
                     assert_eq!(actual.into_iter().rev().count(), expected.len());
@@ -653,6 +656,7 @@ mod test {
                 #[test]
                 fn in_order() {
                     let expected = [0, 1, 2, 3, 4, 5];
+
                     let actual = Fixed::from(expected);
 
                     assert!(actual.into_iter().rev().eq(expected.into_iter().rev()));

--- a/src/structure/collection/linear/array/fixed.rs
+++ b/src/structure/collection/linear/array/fixed.rs
@@ -638,7 +638,7 @@ mod test {
                     })).into_iter();
 
                     for _ in 0..yielded {
-                        // Yield element so lifetime is caller responsibility.
+                        // Caller is responsible for this yielded lifetime.
                         drop(actual.next());
                     }
 
@@ -689,7 +689,7 @@ mod test {
                         })).into_iter();
 
                         for _ in 0..yielded {
-                            // Yield element so lifetime is caller responsibility.
+                            // Caller is responsible for this yielded lifetime.
                             drop(actual.next_back());
                         }
 

--- a/src/structure/collection/linear/array/fixed.rs
+++ b/src/structure/collection/linear/array/fixed.rs
@@ -630,15 +630,28 @@ mod test {
 
                 const ELEMENTS: usize = 256;
 
-                let dropped = DropCounter::new_counter();
+                for yielded in 0..ELEMENTS {
+                    let dropped = DropCounter::new_counter();
 
-                let actual = Fixed::from(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                    DropCounter::new(&dropped)
-                }));
+                    let mut actual = Fixed::from(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                        DropCounter::new(&dropped)
+                    })).into_iter();
 
-                drop(actual.into_iter());
+                    for _ in 0..yielded {
+                        // Yield element so lifetime is caller responsibility.
+                        drop(actual.next());
+                    }
 
-                assert_eq!(dropped.take(), ELEMENTS);
+                    // Reset the counter so we do not count elements that were
+                    // yielded and then manually dropped in the above loop.
+                    _ = dropped.replace(0);
+
+                    // Now we drop the iterator which should implicitly drop
+                    // all the elements that were not yielded.
+                    drop(actual);
+
+                    assert_eq!(dropped.take(), ELEMENTS - yielded);
+                }
             }
 
             mod double_ended {

--- a/src/structure/collection/linear/array/fixed.rs
+++ b/src/structure/collection/linear/array/fixed.rs
@@ -624,59 +624,41 @@ mod test {
                 assert!(actual.into_iter().eq(expected.into_iter()));
             }
 
-            #[test]
-            fn drops_back_elements_yet_to_be_yielded() {
-                use crate::test::mock::DropCounter;
-
-                const ELEMENTS: usize = 256;
-
-                for yielded in 0..ELEMENTS {
-                    let dropped = DropCounter::new_counter();
-
-                    let mut actual = Fixed::from(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                        DropCounter::new(&dropped)
-                    })).into_iter();
-
-                    for _ in 0..yielded {
-                        // Caller is responsible for this yielded lifetime.
-                        drop(actual.next());
-                    }
-
-                    // Reset the counter so we do not count elements that were
-                    // yielded and then manually dropped in the above loop.
-                    _ = dropped.replace(0);
-
-                    // Now we drop the iterator which should implicitly drop
-                    // all the elements that were not yielded.
-                    drop(actual);
-
-                    assert_eq!(dropped.take(), ELEMENTS - yielded);
-                }
-            }
-
-            mod double_ended {
+            mod drop {
                 use super::*;
 
                 #[test]
-                fn element_count() {
-                    let expected = [0, 1, 2, 3, 4, 5];
+                fn drops_unyielded_elements_when_advanced_from_front() {
+                    use crate::test::mock::DropCounter;
 
-                    let actual = Fixed::from(expected);
+                    const ELEMENTS: usize = 256;
 
-                    assert_eq!(actual.into_iter().rev().count(), expected.len());
+                    for yielded in 0..ELEMENTS {
+                        let dropped = DropCounter::new_counter();
+
+                        let mut actual = Fixed::from(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                            DropCounter::new(&dropped)
+                        })).into_iter();
+
+                        for _ in 0..yielded {
+                            // Caller is responsible for this yielded lifetime.
+                            drop(actual.next());
+                        }
+
+                        // Reset the counter so we do not count elements that were
+                        // yielded and then manually dropped in the above loop.
+                        _ = dropped.replace(0);
+
+                        // Now we drop the iterator which should implicitly drop
+                        // all the elements that were not yielded.
+                        drop(actual);
+
+                        assert_eq!(dropped.take(), ELEMENTS - yielded);
+                    }
                 }
 
                 #[test]
-                fn in_order() {
-                    let expected = [0, 1, 2, 3, 4, 5];
-
-                    let actual = Fixed::from(expected);
-
-                    assert!(actual.into_iter().rev().eq(expected.into_iter().rev()));
-                }
-
-                #[test]
-                fn drops_front_elements_yet_to_be_yielded() {
+                fn drops_unyielded_elements_when_advanced_from_back() {
                     use crate::test::mock::DropCounter;
 
                     const ELEMENTS: usize = 256;
@@ -706,7 +688,7 @@ mod test {
                 }
 
                 #[test]
-                fn drops_middle_elements_yet_to_be_yielded() {
+                fn drops_unyielded_elements_when_advanced_from_both_ends() {
                     use crate::test::mock::DropCounter;
 
                     const ELEMENTS: usize = 256;
@@ -734,6 +716,28 @@ mod test {
 
                         assert_eq!(dropped.take(), ELEMENTS - yielded);
                     }
+                }
+            }
+
+            mod double_ended {
+                use super::*;
+
+                #[test]
+                fn element_count() {
+                    let expected = [0, 1, 2, 3, 4, 5];
+
+                    let actual = Fixed::from(expected);
+
+                    assert_eq!(actual.into_iter().rev().count(), expected.len());
+                }
+
+                #[test]
+                fn in_order() {
+                    let expected = [0, 1, 2, 3, 4, 5];
+
+                    let actual = Fixed::from(expected);
+
+                    assert!(actual.into_iter().rev().eq(expected.into_iter().rev()));
                 }
             }
 

--- a/src/structure/collection/linear/array/fixed.rs
+++ b/src/structure/collection/linear/array/fixed.rs
@@ -636,9 +636,11 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        let mut actual = Fixed::from(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        })).into_iter();
+                        let mut actual =
+                            Fixed::from(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }))
+                            .into_iter();
 
                         for _ in 0..yielded {
                             // Lifetime is passed to caller.
@@ -666,9 +668,11 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        let mut actual = Fixed::from(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        })).into_iter();
+                        let mut actual =
+                            Fixed::from(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }))
+                            .into_iter();
 
                         for _ in 0..yielded {
                             // Lifetime is passed to caller.
@@ -697,9 +701,11 @@ mod test {
                         for back in front..ELEMENTS {
                             let dropped = DropCounter::new_counter();
 
-                            let mut actual = Fixed::from(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                                DropCounter::new(&dropped)
-                            })).into_iter();
+                            let mut actual =
+                                Fixed::from(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                    DropCounter::new(&dropped)
+                                }))
+                                .into_iter();
 
                             for _ in 0..front {
                                 // Lifetime is passed to caller.

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -2255,10 +2255,15 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
-                        let mut actual = Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        })).into_iter();
+                        #[expect(
+                            clippy::useless_conversion,
+                            reason = "explicitly testing into iterator"
+                        )]
+                        let mut actual =
+                            Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }))
+                            .into_iter();
 
                         for _ in 0..yielded {
                             // Lifetime is passed to caller.
@@ -2286,10 +2291,15 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
-                        let mut actual = Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        })).into_iter();
+                        #[expect(
+                            clippy::useless_conversion,
+                            reason = "explicitly testing into iterator"
+                        )]
+                        let mut actual =
+                            Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }))
+                            .into_iter();
 
                         for _ in 0..yielded {
                             // Lifetime is passed to caller.
@@ -2318,10 +2328,15 @@ mod test {
                         for back in front..ELEMENTS {
                             let dropped = DropCounter::new_counter();
 
-                            #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
-                            let mut actual = Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                                DropCounter::new(&dropped)
-                            })).into_iter();
+                            #[expect(
+                                clippy::useless_conversion,
+                                reason = "explicitly testing into iterator"
+                            )]
+                            let mut actual =
+                                Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                    DropCounter::new(&dropped)
+                                }))
+                                .into_iter();
 
                             for _ in 0..front {
                                 // Lifetime is passed to caller.
@@ -3633,9 +3648,10 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        let mut actual = Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        }));
+                        let mut actual =
+                            Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }));
 
                         let mut actual = actual.drain(..);
 
@@ -3665,9 +3681,10 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        let mut actual = Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        }));
+                        let mut actual =
+                            Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }));
 
                         let mut actual = actual.drain(..);
 
@@ -3698,9 +3715,10 @@ mod test {
                         for back in front..ELEMENTS {
                             let dropped = DropCounter::new_counter();
 
-                            let mut actual = Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                                DropCounter::new(&dropped)
-                            }));
+                            let mut actual =
+                                Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                    DropCounter::new(&dropped)
+                                }));
 
                             let mut actual = actual.drain(..);
 
@@ -3812,6 +3830,7 @@ mod test {
 
                     assert!(actual.eq([0, 2, 4]));
                 }
+
                 #[test]
                 fn size_hint() {
                     let mut underlying = Doubly::from_iter([0, 1, 2, 3, 4, 5]);
@@ -3917,9 +3936,10 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        let mut actual = Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        }));
+                        let mut actual =
+                            Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }));
 
                         let mut actual = actual.withdraw(|_| true);
 
@@ -3949,9 +3969,10 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        let mut actual = Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        }));
+                        let mut actual =
+                            Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }));
 
                         let mut actual = actual.withdraw(|_| true);
 
@@ -3982,9 +4003,10 @@ mod test {
                         for back in front..ELEMENTS {
                             let dropped = DropCounter::new_counter();
 
-                            let mut actual = Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                                DropCounter::new(&dropped)
-                            }));
+                            let mut actual =
+                                Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                    DropCounter::new(&dropped)
+                                }));
 
                             let mut actual = actual.withdraw(|_| true);
 

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -3512,6 +3512,20 @@ mod test {
 
                         assert!(actual.drain(1..4).rev().eq(expected.drain(1..4).rev()));
                     }
+
+                    #[test]
+                    fn prevents_elements_from_being_yielded_more_than_once() {
+                        let mut underlying = Doubly::from_iter([0, 1, 2, 0]);
+
+                        let mut actual = underlying.drain(1..=2);
+
+                        // make head and tail meet.
+                        _ = actual.next().expect("the element with value '1'");
+                        _ = actual.next_back().expect("the element with value '2'");
+
+                        assert_eq!(actual.next(), None);
+                        assert_eq!(actual.next_back(), None);
+                    }
                 }
 
                 mod exact_size {

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -3569,7 +3569,7 @@ mod test {
                     use super::*;
 
                     #[test]
-                    fn empty() {
+                    fn when_empty() {
                         let mut actual = Doubly::<()>::default();
                         let mut actual = actual.drain(..);
 
@@ -3583,7 +3583,7 @@ mod test {
                     }
 
                     #[test]
-                    fn exhausted() {
+                    fn when_exhausted() {
                         let mut actual: Doubly<_> = [()].into_iter().collect();
                         let mut actual = actual.drain(..);
 

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -3681,20 +3681,32 @@ mod test {
 
                 #[test]
                 fn does_not_modify_leading_elements() {
-                    let mut actual = Doubly::from_iter([0, 1, 2, 3, 4, 5]);
+                    const ELEMENTS: usize = 256;
 
-                    drop(actual.drain(3..));
+                    let expected = core::array::from_fn::<_, ELEMENTS, _>(|index| index);
 
-                    assert!(actual.eq([0, 1, 2]));
+                    for start in 0..ELEMENTS {
+                        let mut actual: Doubly<_> = expected.iter().copied().collect();
+
+                        drop(actual.drain(start..));
+
+                        assert!(actual.iter().eq(expected[..start].iter()));
+                    }
                 }
 
                 #[test]
                 fn does_not_modify_trailing_elements() {
-                    let mut actual = Doubly::from_iter([0, 1, 2, 3, 4, 5]);
+                    const ELEMENTS: usize = 256;
 
-                    drop(actual.drain(..3));
+                    let expected = core::array::from_fn::<_, ELEMENTS, _>(|index| index);
 
-                    assert!(actual.eq([3, 4, 5]));
+                    for end in 0..ELEMENTS {
+                        let mut actual: Doubly<_> = expected.iter().copied().collect();
+
+                        drop(actual.drain(..end));
+
+                        assert!(actual.iter().eq(expected[end..].iter()));
+                    }
                 }
 
                 #[test]

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -2294,6 +2294,37 @@ mod test {
 
                     assert!(actual.into_iter().rev().eq(expected.into_iter().rev()));
                 }
+
+                #[test]
+                fn drops_front_elements_yet_to_be_yielded() {
+                    use crate::test::mock::DropCounter;
+
+                    const ELEMENTS: usize = 256;
+
+                    for yielded in 0..ELEMENTS {
+                        let dropped = DropCounter::new_counter();
+
+                        #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
+                        let mut actual = Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                            DropCounter::new(&dropped)
+                        })).into_iter();
+
+                        for _ in 0..yielded {
+                            // Caller is responsible for this yielded lifetime.
+                            drop(actual.next_back());
+                        }
+
+                        // Reset the counter so we do not count elements that were
+                        // yielded and then manually dropped in the above loop.
+                        _ = dropped.replace(0);
+
+                        // Now we drop the iterator which should implicitly drop
+                        // all the elements that were not yielded.
+                        drop(actual);
+
+                        assert_eq!(dropped.take(), ELEMENTS - yielded);
+                    }
+                }
             }
 
             mod exact_size {

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -3711,11 +3711,22 @@ mod test {
 
                 #[test]
                 fn combines_leading_and_trailing_elements() {
-                    let mut actual = Doubly::from_iter([0, 1, 2, 3, 4, 5]);
+                    const ELEMENTS: usize = 8;
 
-                    drop(actual.drain(1..=4));
+                    let expected = core::array::from_fn::<_, ELEMENTS, _>(|index| index);
 
-                    assert!(actual.eq([0, 5]));
+                    for start in 0..ELEMENTS {
+                        for end in start..ELEMENTS {
+                            let mut actual: Doubly<_> = expected.iter().copied().collect();
+
+                            drop(actual.drain(start..end));
+
+                            let expected_leading = expected[..start].iter();
+                            let expected_trailing = expected[end..].iter();
+
+                            assert!(actual.iter().eq(expected_leading.chain(expected_trailing)));
+                        }
+                    }
                 }
             }
         }

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -3559,7 +3559,7 @@ mod test {
                     #[test]
                     fn empty() {
                         let mut actual = Doubly::<()>::default();
-                        let mut actual = actual.drain(0..=0);
+                        let mut actual = actual.drain(..);
 
                         // Yields `None` at least once.
                         assert_eq!(actual.next(), None);
@@ -3573,7 +3573,7 @@ mod test {
                     #[test]
                     fn exhausted() {
                         let mut actual: Doubly<_> = [()].into_iter().collect();
-                        let mut actual = actual.drain(0..=0);
+                        let mut actual = actual.drain(..);
 
                         // Exhaust the elements.
                         let _: () = actual.next().expect("the one element");

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -3464,7 +3464,7 @@ mod test {
             fn none_when_out_of_bounds_range() {
                 let mut instance = Doubly::from_iter([0, 1, 2, 3, 4, 5]);
 
-                let mut actual = instance.drain(256..);
+                let mut actual = instance.drain(6..);
 
                 assert_eq!(actual.next(), None);
                 assert_eq!(actual.next_back(), None);

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -3460,32 +3460,30 @@ mod test {
         mod drain {
             use super::*;
 
-            #[test]
-            fn none_when_out_of_bounds_range() {
-                let mut instance = Doubly::from_iter([0, 1, 2, 3, 4, 5]);
-
-                let mut actual = instance.drain(6..);
-
-                assert_eq!(actual.next(), None);
-                assert_eq!(actual.next_back(), None);
-
-                drop(actual);
-            }
-
-            #[test]
-            fn none_when_empty() {
-                let mut instance = Doubly::<()>::default();
-
-                let mut actual = instance.drain(..);
-
-                assert_eq!(actual.next(), None);
-                assert_eq!(actual.next_back(), None);
-
-                drop(actual);
-            }
-
             mod iterator {
                 use super::*;
+
+                #[test]
+                fn yields_no_elements_when_empty() {
+                    let mut actual = Doubly::<()>::default();
+
+                    let mut actual = actual.drain(..);
+
+                    assert_eq!(actual.next(), None);
+
+                    drop(actual);
+                }
+
+                #[test]
+                fn yields_no_elements_when_range_is_out_of_bounds() {
+                    let mut actual = Doubly::from_iter([0, 1, 2, 3, 4, 5]);
+
+                    let mut actual = actual.drain(6..);
+
+                    assert_eq!(actual.next(), None);
+
+                    drop(actual);
+                }
 
                 #[test]
                 fn element_count() {
@@ -3505,6 +3503,28 @@ mod test {
 
                 mod double_ended {
                     use super::*;
+
+                    #[test]
+                    fn yields_no_elements_when_empty() {
+                        let mut actual = Doubly::<()>::default();
+
+                        let mut actual = actual.drain(..);
+
+                        assert_eq!(actual.next_back(), None);
+
+                        drop(actual);
+                    }
+
+                    #[test]
+                    fn yields_no_elements_when_range_is_out_of_bounds() {
+                        let mut actual = Doubly::from_iter([0, 1, 2, 3, 4, 5]);
+
+                        let mut actual = actual.drain(6..);
+
+                        assert_eq!(actual.next_back(), None);
+
+                        drop(actual);
+                    }
 
                     #[test]
                     fn element_count() {

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -3472,6 +3472,18 @@ mod test {
                 drop(actual);
             }
 
+            #[test]
+            fn none_when_empty() {
+                let mut instance = Doubly::<()>::default();
+
+                let mut actual = instance.drain(..);
+
+                assert_eq!(actual.next(), None);
+                assert_eq!(actual.next_back(), None);
+
+                drop(actual);
+            }
+
             mod iterator {
                 use super::*;
 

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -3490,14 +3490,21 @@ mod test {
                 }
 
                 #[test]
-                fn yields_no_elements_when_range_is_out_of_bounds() {
+                fn yields_no_elements_when_start_of_range_is_out_of_bounds() {
                     let mut actual = Doubly::from_iter([0, 1, 2, 3, 4, 5]);
 
                     let mut actual = actual.drain(6..);
 
                     assert_eq!(actual.next(), None);
+                }
 
-                    drop(actual);
+                #[test]
+                fn yields_elements_when_end_of_range_is_out_of_bounds() {
+                    let mut actual = Doubly::from_iter([0, 1, 2, 3, 4, 5]);
+
+                    let actual = actual.drain(..usize::MAX);
+
+                    assert!(actual.eq([0, 1, 2, 3, 4, 5]));
                 }
 
                 #[test]
@@ -3531,14 +3538,21 @@ mod test {
                     }
 
                     #[test]
-                    fn yields_no_elements_when_range_is_out_of_bounds() {
+                    fn yields_no_elements_when_start_of_range_is_out_of_bounds() {
                         let mut actual = Doubly::from_iter([0, 1, 2, 3, 4, 5]);
 
                         let mut actual = actual.drain(6..);
 
                         assert_eq!(actual.next_back(), None);
+                    }
 
-                        drop(actual);
+                    #[test]
+                    fn yields_elements_when_end_of_range_is_out_of_bounds() {
+                        let mut actual = Doubly::from_iter([0, 1, 2, 3, 4, 5]);
+
+                        let actual = actual.drain(..usize::MAX).rev();
+
+                        assert!(actual.eq([5, 4, 3, 2, 1, 0]));
                     }
 
                     #[test]

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -3670,6 +3670,16 @@ mod test {
                 }
 
                 #[test]
+                fn can_drain_all_elements() {
+                    let mut actual = Doubly::from_iter([0, 1, 2, 3, 4, 5]);
+
+                    drop(actual.drain(..));
+
+                    assert!(actual.head.is_none());
+                    assert!(actual.tail.is_none());
+                }
+
+                #[test]
                 fn does_not_modify_leading_elements() {
                     let mut actual = Doubly::from_iter([0, 1, 2, 3, 4, 5]);
 

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -2325,6 +2325,38 @@ mod test {
                         assert_eq!(dropped.take(), ELEMENTS - yielded);
                     }
                 }
+
+                #[test]
+                fn drops_middle_elements_yet_to_be_yielded() {
+                    use crate::test::mock::DropCounter;
+
+                    const ELEMENTS: usize = 256;
+
+                    for yielded in (0..ELEMENTS).step_by(2) {
+                        let dropped = DropCounter::new_counter();
+
+                        #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
+                        let mut actual = Doubly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                            DropCounter::new(&dropped)
+                        })).into_iter();
+
+                        for _ in (0..yielded).step_by(2) {
+                            // Caller is responsible for these yielded lifetimes.
+                            drop(actual.next());
+                            drop(actual.next_back());
+                        }
+
+                        // Reset the counter so we do not count elements that were
+                        // yielded and then manually dropped in the above loop.
+                        _ = dropped.replace(0);
+
+                        // Now we drop the iterator which should implicitly drop
+                        // all the elements that were not yielded.
+                        drop(actual);
+
+                        assert_eq!(dropped.take(), ELEMENTS - yielded);
+                    }
+                }
             }
 
             mod exact_size {

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -3187,6 +3187,20 @@ mod test {
 
                         assert!(actual.drain(1..4).rev().eq(expected.drain(1..4).rev()));
                     }
+
+                    #[test]
+                    fn prevents_elements_from_being_yielded_more_than_once() {
+                        let mut underlying = Singly::from_iter([0, 1, 2, 0]);
+
+                        let mut actual = underlying.drain(1..=2);
+
+                        // make head and tail meet.
+                        _ = actual.next().expect("the element with value '1'");
+                        _ = actual.next_back().expect("the element with value '2'");
+
+                        assert_eq!(actual.next(), None);
+                        assert_eq!(actual.next_back(), None);
+                    }
                 }
 
                 mod exact_size {

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -3147,6 +3147,18 @@ mod test {
                 drop(actual);
             }
 
+            #[test]
+            fn none_when_empty() {
+                let mut instance = Singly::<()>::default();
+
+                let mut actual = instance.drain(..);
+
+                assert_eq!(actual.next(), None);
+                assert_eq!(actual.next_back(), None);
+
+                drop(actual);
+            }
+
             mod iterator {
                 use super::*;
 

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -3135,32 +3135,30 @@ mod test {
         mod drain {
             use super::*;
 
-            #[test]
-            fn none_when_out_of_bounds_range() {
-                let mut instance = Singly::from_iter([0, 1, 2, 3, 4, 5]);
-
-                let mut actual = instance.drain(6..);
-
-                assert_eq!(actual.next(), None);
-                assert_eq!(actual.next_back(), None);
-
-                drop(actual);
-            }
-
-            #[test]
-            fn none_when_empty() {
-                let mut instance = Singly::<()>::default();
-
-                let mut actual = instance.drain(..);
-
-                assert_eq!(actual.next(), None);
-                assert_eq!(actual.next_back(), None);
-
-                drop(actual);
-            }
-
             mod iterator {
                 use super::*;
+
+                #[test]
+                fn yields_no_elements_when_empty() {
+                    let mut actual = Singly::<()>::default();
+
+                    let mut actual = actual.drain(..);
+
+                    assert_eq!(actual.next(), None);
+
+                    drop(actual);
+                }
+
+                #[test]
+                fn yields_no_elements_when_range_is_out_of_bounds() {
+                    let mut actual = Singly::from_iter([0, 1, 2, 3, 4, 5]);
+
+                    let mut actual = actual.drain(6..);
+
+                    assert_eq!(actual.next(), None);
+
+                    drop(actual);
+                }
 
                 #[test]
                 fn element_count() {
@@ -3180,6 +3178,28 @@ mod test {
 
                 mod double_ended {
                     use super::*;
+
+                    #[test]
+                    fn yields_no_elements_when_empty() {
+                        let mut actual = Singly::<()>::default();
+
+                        let mut actual = actual.drain(..);
+
+                        assert_eq!(actual.next_back(), None);
+
+                        drop(actual);
+                    }
+
+                    #[test]
+                    fn yields_no_elements_when_range_is_out_of_bounds() {
+                        let mut actual = Singly::from_iter([0, 1, 2, 3, 4, 5]);
+
+                        let mut actual = actual.drain(6..);
+
+                        assert_eq!(actual.next_back(), None);
+
+                        drop(actual);
+                    }
 
                     #[test]
                     fn element_count() {

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -3165,14 +3165,22 @@ mod test {
                 }
 
                 #[test]
-                fn yields_no_elements_when_range_is_out_of_bounds() {
+                fn yields_no_elements_when_start_of_range_is_out_of_bounds() {
                     let mut actual = Singly::from_iter([0, 1, 2, 3, 4, 5]);
 
                     let mut actual = actual.drain(6..);
 
                     assert_eq!(actual.next(), None);
+                    assert_eq!(actual.next_back(), None);
+                }
 
-                    drop(actual);
+                #[test]
+                fn yields_elements_when_end_of_range_is_out_of_bounds() {
+                    let mut actual = Singly::from_iter([0, 1, 2, 3, 4, 5]);
+
+                    let actual = actual.drain(..usize::MAX);
+
+                    assert!(actual.eq([0, 1, 2, 3, 4, 5]));
                 }
 
                 #[test]
@@ -3206,14 +3214,21 @@ mod test {
                     }
 
                     #[test]
-                    fn yields_no_elements_when_range_is_out_of_bounds() {
+                    fn yields_no_elements_when_start_of_range_is_out_of_bounds() {
                         let mut actual = Singly::from_iter([0, 1, 2, 3, 4, 5]);
 
                         let mut actual = actual.drain(6..);
 
                         assert_eq!(actual.next_back(), None);
+                    }
 
-                        drop(actual);
+                    #[test]
+                    fn yields_elements_when_end_of_range_is_out_of_bounds() {
+                        let mut actual = Singly::from_iter([0, 1, 2, 3, 4, 5]);
+
+                        let actual = actual.drain(..usize::MAX).rev();
+
+                        assert!(actual.eq([5, 4, 3, 2, 1, 0]));
                     }
 
                     #[test]

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -1927,60 +1927,42 @@ mod test {
                 assert!(actual.into_iter().eq(expected));
             }
 
-            #[test]
-            fn drops_back_elements_yet_to_be_yielded() {
-                use crate::test::mock::DropCounter;
-
-                const ELEMENTS: usize = 256;
-
-                for yielded in 0..ELEMENTS {
-                    let dropped = DropCounter::new_counter();
-
-                    #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
-                    let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                        DropCounter::new(&dropped)
-                    })).into_iter();
-
-                    for _ in 0..yielded {
-                        // Caller is responsible for this yielded lifetime.
-                        drop(actual.next());
-                    }
-
-                    // Reset the counter so we do not count elements that were
-                    // yielded and then manually dropped in the above loop.
-                    _ = dropped.replace(0);
-
-                    // Now we drop the iterator which should implicitly drop
-                    // all the elements that were not yielded.
-                    drop(actual);
-
-                    assert_eq!(dropped.take(), ELEMENTS - yielded);
-                }
-            }
-
-            mod double_ended {
+            mod drop {
                 use super::*;
 
                 #[test]
-                fn element_count() {
-                    let expected = [0, 1, 2, 3, 4, 5];
+                fn drops_unyielded_elements_when_advanced_from_front() {
+                    use crate::test::mock::DropCounter;
 
-                    let actual: Singly<_> = expected.iter().copied().collect();
+                    const ELEMENTS: usize = 256;
 
-                    assert_eq!(actual.into_iter().rev().len(), expected.len());
+                    for yielded in 0..ELEMENTS {
+                        let dropped = DropCounter::new_counter();
+
+                        #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
+                        let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                            DropCounter::new(&dropped)
+                        })).into_iter();
+
+                        for _ in 0..yielded {
+                            // Caller is responsible for this yielded lifetime.
+                            drop(actual.next());
+                        }
+
+                        // Reset the counter so we do not count elements that were
+                        // yielded and then manually dropped in the above loop.
+                        _ = dropped.replace(0);
+
+                        // Now we drop the iterator which should implicitly drop
+                        // all the elements that were not yielded.
+                        drop(actual);
+
+                        assert_eq!(dropped.take(), ELEMENTS - yielded);
+                    }
                 }
 
                 #[test]
-                fn in_order() {
-                    let expected = [0, 1, 2, 3, 4, 5];
-
-                    let actual: Singly<_> = expected.iter().copied().collect();
-
-                    assert!(actual.into_iter().rev().eq(expected.into_iter().rev()));
-                }
-
-                #[test]
-                fn drops_front_elements_yet_to_be_yielded() {
+                fn drops_unyielded_elements_when_advanced_from_back() {
                     use crate::test::mock::DropCounter;
 
                     const ELEMENTS: usize = 256;
@@ -2011,7 +1993,7 @@ mod test {
                 }
 
                 #[test]
-                fn drops_middle_elements_yet_to_be_yielded() {
+                fn drops_unyielded_elements_when_advanced_from_both_ends() {
                     use crate::test::mock::DropCounter;
 
                     const ELEMENTS: usize = 256;
@@ -2040,6 +2022,28 @@ mod test {
 
                         assert_eq!(dropped.take(), ELEMENTS - yielded);
                     }
+                }
+            }
+
+            mod double_ended {
+                use super::*;
+
+                #[test]
+                fn element_count() {
+                    let expected = [0, 1, 2, 3, 4, 5];
+
+                    let actual: Singly<_> = expected.iter().copied().collect();
+
+                    assert_eq!(actual.into_iter().rev().len(), expected.len());
+                }
+
+                #[test]
+                fn in_order() {
+                    let expected = [0, 1, 2, 3, 4, 5];
+
+                    let actual: Singly<_> = expected.iter().copied().collect();
+
+                    assert!(actual.into_iter().rev().eq(expected.into_iter().rev()));
                 }
             }
 

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -1927,6 +1927,37 @@ mod test {
                 assert!(actual.into_iter().eq(expected));
             }
 
+            #[test]
+            fn drops_back_elements_yet_to_be_yielded() {
+                use crate::test::mock::DropCounter;
+
+                const ELEMENTS: usize = 256;
+
+                for yielded in 0..ELEMENTS {
+                    let dropped = DropCounter::new_counter();
+
+                    #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
+                    let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                        DropCounter::new(&dropped)
+                    })).into_iter();
+
+                    for _ in 0..yielded {
+                        // Caller is responsible for this yielded lifetime.
+                        drop(actual.next());
+                    }
+
+                    // Reset the counter so we do not count elements that were
+                    // yielded and then manually dropped in the above loop.
+                    _ = dropped.replace(0);
+
+                    // Now we drop the iterator which should implicitly drop
+                    // all the elements that were not yielded.
+                    drop(actual);
+
+                    assert_eq!(dropped.take(), ELEMENTS - yielded);
+                }
+            }
+
             mod double_ended {
                 use super::*;
 

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -1978,6 +1978,37 @@ mod test {
 
                     assert!(actual.into_iter().rev().eq(expected.into_iter().rev()));
                 }
+
+                #[test]
+                fn drops_front_elements_yet_to_be_yielded() {
+                    use crate::test::mock::DropCounter;
+
+                    const ELEMENTS: usize = 256;
+
+                    for yielded in 0..ELEMENTS {
+                        let dropped = DropCounter::new_counter();
+
+                        #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
+                        let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                            DropCounter::new(&dropped)
+                        })).into_iter();
+
+                        for _ in 0..yielded {
+                            // Caller is responsible for this yielded lifetime.
+                            drop(actual.next_back());
+                        }
+
+                        // Reset the counter so we do not count elements that were
+                        // yielded and then manually dropped in the above loop.
+                        _ = dropped.replace(0);
+
+                        // Now we drop the iterator which should implicitly drop
+                        // all the elements that were not yielded.
+                        drop(actual);
+
+                        assert_eq!(dropped.take(), ELEMENTS - yielded);
+                    }
+                }
             }
 
             mod exact_size {

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -1934,7 +1934,7 @@ mod test {
                 fn drops_unyielded_elements_when_advanced_from_front() {
                     use crate::test::mock::DropCounter;
 
-                    const ELEMENTS: usize = 256;
+                    const ELEMENTS: usize = 8;
 
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
@@ -1945,16 +1945,16 @@ mod test {
                         })).into_iter();
 
                         for _ in 0..yielded {
-                            // Caller is responsible for this yielded lifetime.
+                            // Lifetime is passed to caller.
                             drop(actual.next());
                         }
 
-                        // Reset the counter so we do not count elements that were
-                        // yielded and then manually dropped in the above loop.
-                        _ = dropped.replace(0);
+                        // The above drops in caller scope, not the
+                        // destructor being tested, so reset counter.
+                        debug_assert_eq!(dropped.replace(0), yielded);
 
-                        // Now we drop the iterator which should implicitly drop
-                        // all the elements that were not yielded.
+                        // Now we drop the iterator, so we expect all
+                        // remaining elements to be dropped.
                         drop(actual);
 
                         assert_eq!(dropped.take(), ELEMENTS - yielded);
@@ -1965,7 +1965,7 @@ mod test {
                 fn drops_unyielded_elements_when_advanced_from_back() {
                     use crate::test::mock::DropCounter;
 
-                    const ELEMENTS: usize = 256;
+                    const ELEMENTS: usize = 8;
 
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
@@ -1976,16 +1976,16 @@ mod test {
                         })).into_iter();
 
                         for _ in 0..yielded {
-                            // Caller is responsible for this yielded lifetime.
+                            // Lifetime is passed to caller.
                             drop(actual.next_back());
                         }
 
-                        // Reset the counter so we do not count elements that were
-                        // yielded and then manually dropped in the above loop.
-                        _ = dropped.replace(0);
+                        // The above drops in caller scope, not the
+                        // destructor being tested, so reset counter.
+                        debug_assert_eq!(dropped.replace(0), yielded);
 
-                        // Now we drop the iterator which should implicitly drop
-                        // all the elements that were not yielded.
+                        // Now we drop the iterator, so we expect all
+                        // remaining elements to be dropped.
                         drop(actual);
 
                         assert_eq!(dropped.take(), ELEMENTS - yielded);
@@ -1996,31 +1996,37 @@ mod test {
                 fn drops_unyielded_elements_when_advanced_from_both_ends() {
                     use crate::test::mock::DropCounter;
 
-                    const ELEMENTS: usize = 256;
+                    const ELEMENTS: usize = 8;
 
-                    for yielded in (0..ELEMENTS).step_by(2) {
-                        let dropped = DropCounter::new_counter();
+                    for front in 0..ELEMENTS {
+                        for back in front..ELEMENTS {
+                            let dropped = DropCounter::new_counter();
 
-                        #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
-                        let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        })).into_iter();
+                            #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
+                            let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            })).into_iter();
 
-                        for _ in (0..yielded).step_by(2) {
-                            // Caller is responsible for these yielded lifetimes.
-                            drop(actual.next());
-                            drop(actual.next_back());
+                            for _ in 0..front {
+                                // Lifetime is passed to caller.
+                                drop(actual.next());
+                            }
+
+                            for _ in front..back {
+                                // Lifetime is passed to caller.
+                                drop(actual.next_back());
+                            }
+
+                            // The above drops in caller scope, not the
+                            // destructor being tested, so reset counter.
+                            let expected = ELEMENTS - dropped.replace(0);
+
+                            // Now we drop the iterator, so we expect all
+                            // remaining elements to be dropped.
+                            drop(actual);
+
+                            assert_eq!(dropped.take(), expected);
                         }
-
-                        // Reset the counter so we do not count elements that were
-                        // yielded and then manually dropped in the above loop.
-                        _ = dropped.replace(0);
-
-                        // Now we drop the iterator which should implicitly drop
-                        // all the elements that were not yielded.
-                        drop(actual);
-
-                        assert_eq!(dropped.take(), ELEMENTS - yielded);
                     }
                 }
             }

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -3234,7 +3234,7 @@ mod test {
                     #[test]
                     fn empty() {
                         let mut actual = Singly::<()>::default();
-                        let mut actual = actual.drain(0..=0);
+                        let mut actual = actual.drain(..);
 
                         // Yields `None` at least once.
                         assert_eq!(actual.next(), None);
@@ -3248,7 +3248,7 @@ mod test {
                     #[test]
                     fn exhausted() {
                         let mut actual: Singly<_> = [()].into_iter().collect();
-                        let mut actual = actual.drain(0..=0);
+                        let mut actual = actual.drain(..);
 
                         // Exhaust the elements.
                         let _: () = actual.next().expect("the one element");

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -3139,7 +3139,7 @@ mod test {
             fn none_when_out_of_bounds_range() {
                 let mut instance = Singly::from_iter([0, 1, 2, 3, 4, 5]);
 
-                let mut actual = instance.drain(256..);
+                let mut actual = instance.drain(6..);
 
                 assert_eq!(actual.next(), None);
                 assert_eq!(actual.next_back(), None);

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -3254,52 +3254,165 @@ mod test {
                 use super::*;
 
                 #[test]
-                fn drops_yet_to_be_yielded_elements() {
+                fn drops_unyielded_elements_when_advanced_from_front() {
                     use crate::test::mock::DropCounter;
 
-                    const ELEMENTS: usize = 256;
+                    const ELEMENTS: usize = 8;
 
-                    let dropped = DropCounter::new_counter();
+                    for yielded in 0..ELEMENTS {
+                        let dropped = DropCounter::new_counter();
 
-                    let mut actual = Singly::<DropCounter>::default();
+                        let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                            DropCounter::new(&dropped)
+                        }));
 
-                    for _ in 0..ELEMENTS {
-                        _ = actual
-                            .append(DropCounter::new(&dropped))
-                            .expect("successful allocation");
+                        let mut actual = actual.drain(..);
+
+                        for _ in 0..yielded {
+                            // Lifetime is passed to caller.
+                            drop(actual.next());
+                        }
+
+                        // The above drops in caller scope, not the
+                        // destructor being tested, so reset counter.
+                        debug_assert_eq!(dropped.replace(0), yielded);
+
+                        // Now we drop the iterator, so we expect all
+                        // remaining elements to be dropped.
+                        drop(actual);
+
+                        assert_eq!(dropped.take(), ELEMENTS - yielded);
                     }
+                }
+
+                #[test]
+                fn drops_unyielded_elements_when_advanced_from_back() {
+                    use crate::test::mock::DropCounter;
+
+                    const ELEMENTS: usize = 8;
+
+                    for yielded in 0..ELEMENTS {
+                        let dropped = DropCounter::new_counter();
+
+                        let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                            DropCounter::new(&dropped)
+                        }));
+
+                        let mut actual = actual.drain(..);
+
+                        for _ in 0..yielded {
+                            // Lifetime is passed to caller.
+                            drop(actual.next_back());
+                        }
+
+                        // The above drops in caller scope, not the
+                        // destructor being tested, so reset counter.
+                        debug_assert_eq!(dropped.replace(0), yielded);
+
+                        // Now we drop the iterator, so we expect all
+                        // remaining elements to be dropped.
+                        drop(actual);
+
+                        assert_eq!(dropped.take(), ELEMENTS - yielded);
+                    }
+                }
+
+                #[test]
+                fn drops_unyielded_elements_when_advanced_from_both_ends() {
+                    use crate::test::mock::DropCounter;
+
+                    const ELEMENTS: usize = 8;
+
+                    for front in 0..ELEMENTS {
+                        for back in front..ELEMENTS {
+                            let dropped = DropCounter::new_counter();
+
+                            let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }));
+
+                            let mut actual = actual.drain(..);
+
+                            for _ in 0..front {
+                                // Lifetime is passed to caller.
+                                drop(actual.next());
+                            }
+
+                            for _ in front..back {
+                                // Lifetime is passed to caller.
+                                drop(actual.next_back());
+                            }
+
+                            // The above drops in caller scope, not the
+                            // destructor being tested, so reset counter.
+                            let expected = ELEMENTS - dropped.replace(0);
+
+                            // Now we drop the iterator, so we expect all
+                            // remaining elements to be dropped.
+                            drop(actual);
+
+                            assert_eq!(dropped.take(), expected);
+                        }
+                    }
+                }
+
+                #[test]
+                fn can_drain_all_elements() {
+                    let mut actual = Singly::from_iter([0, 1, 2, 3, 4, 5]);
 
                     drop(actual.drain(..));
 
                     assert!(actual.elements.is_none());
-                    assert_eq!(dropped.take(), ELEMENTS);
                 }
 
                 #[test]
                 fn does_not_modify_leading_elements() {
-                    let mut actual = Singly::from_iter([0, 1, 2, 3, 4, 5]);
+                    const ELEMENTS: usize = 8;
 
-                    drop(actual.drain(3..));
+                    let expected = core::array::from_fn::<_, ELEMENTS, _>(|index| index);
 
-                    assert!(actual.eq([0, 1, 2]));
+                    for start in 0..ELEMENTS {
+                        let mut actual: Singly<_> = expected.iter().copied().collect();
+
+                        drop(actual.drain(start..));
+
+                        assert!(actual.iter().eq(expected[..start].iter()));
+                    }
                 }
 
                 #[test]
                 fn does_not_modify_trailing_elements() {
-                    let mut actual = Singly::from_iter([0, 1, 2, 3, 4, 5]);
+                    const ELEMENTS: usize = 8;
 
-                    drop(actual.drain(..3));
+                    let expected = core::array::from_fn::<_, ELEMENTS, _>(|index| index);
 
-                    assert!(actual.eq([3, 4, 5]));
+                    for end in 0..ELEMENTS {
+                        let mut actual: Singly<_> = expected.iter().copied().collect();
+
+                        drop(actual.drain(..end));
+
+                        assert!(actual.iter().eq(expected[end..].iter()));
+                    }
                 }
 
                 #[test]
                 fn combines_leading_and_trailing_elements() {
-                    let mut actual = Singly::from_iter([0, 1, 2, 3, 4, 5]);
+                    const ELEMENTS: usize = 8;
 
-                    drop(actual.drain(1..=4));
+                    let expected = core::array::from_fn::<_, ELEMENTS, _>(|index| index);
 
-                    assert!(actual.eq([0, 5]));
+                    for start in 0..ELEMENTS {
+                        for end in start..ELEMENTS {
+                            let mut actual: Singly<_> = expected.iter().copied().collect();
+
+                            drop(actual.drain(start..end));
+
+                            let expected_leading = expected[..start].iter();
+                            let expected_trailing = expected[end..].iter();
+
+                            assert!(actual.iter().eq(expected_leading.chain(expected_trailing)));
+                        }
+                    }
                 }
             }
         }

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -3244,7 +3244,7 @@ mod test {
                     use super::*;
 
                     #[test]
-                    fn empty() {
+                    fn when_empty() {
                         let mut actual = Singly::<()>::default();
                         let mut actual = actual.drain(..);
 
@@ -3258,7 +3258,7 @@ mod test {
                     }
 
                     #[test]
-                    fn exhausted() {
+                    fn when_exhausted() {
                         let mut actual: Singly<_> = [()].into_iter().collect();
                         let mut actual = actual.drain(..);
 

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -1939,10 +1939,15 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
-                        let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        })).into_iter();
+                        #[expect(
+                            clippy::useless_conversion,
+                            reason = "explicitly testing into iterator"
+                        )]
+                        let mut actual =
+                            Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }))
+                            .into_iter();
 
                         for _ in 0..yielded {
                             // Lifetime is passed to caller.
@@ -1970,10 +1975,15 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
-                        let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        })).into_iter();
+                        #[expect(
+                            clippy::useless_conversion,
+                            reason = "explicitly testing into iterator"
+                        )]
+                        let mut actual =
+                            Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }))
+                            .into_iter();
 
                         for _ in 0..yielded {
                             // Lifetime is passed to caller.
@@ -2002,10 +2012,15 @@ mod test {
                         for back in front..ELEMENTS {
                             let dropped = DropCounter::new_counter();
 
-                            #[expect(clippy::useless_conversion, reason = "explicitly testing into iterator")]
-                            let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                                DropCounter::new(&dropped)
-                            })).into_iter();
+                            #[expect(
+                                clippy::useless_conversion,
+                                reason = "explicitly testing into iterator"
+                            )]
+                            let mut actual =
+                                Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                    DropCounter::new(&dropped)
+                                }))
+                                .into_iter();
 
                             for _ in 0..front {
                                 // Lifetime is passed to caller.
@@ -3308,9 +3323,10 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        }));
+                        let mut actual =
+                            Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }));
 
                         let mut actual = actual.drain(..);
 
@@ -3340,9 +3356,10 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        }));
+                        let mut actual =
+                            Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }));
 
                         let mut actual = actual.drain(..);
 
@@ -3373,9 +3390,10 @@ mod test {
                         for back in front..ELEMENTS {
                             let dropped = DropCounter::new_counter();
 
-                            let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                                DropCounter::new(&dropped)
-                            }));
+                            let mut actual =
+                                Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                    DropCounter::new(&dropped)
+                                }));
 
                             let mut actual = actual.drain(..);
 
@@ -3610,9 +3628,10 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        }));
+                        let mut actual =
+                            Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }));
 
                         let mut actual = actual.withdraw(|_| true);
 
@@ -3642,9 +3661,10 @@ mod test {
                     for yielded in 0..ELEMENTS {
                         let dropped = DropCounter::new_counter();
 
-                        let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                            DropCounter::new(&dropped)
-                        }));
+                        let mut actual =
+                            Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                DropCounter::new(&dropped)
+                            }));
 
                         let mut actual = actual.withdraw(|_| true);
 
@@ -3675,9 +3695,10 @@ mod test {
                         for back in front..ELEMENTS {
                             let dropped = DropCounter::new_counter();
 
-                            let mut actual = Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
-                                DropCounter::new(&dropped)
-                            }));
+                            let mut actual =
+                                Singly::from_iter(core::array::from_fn::<_, ELEMENTS, _>(|_| {
+                                    DropCounter::new(&dropped)
+                                }));
 
                             let mut actual = actual.withdraw(|_| true);
 


### PR DESCRIPTION
### Description

Closes #139, closes #79 

### Checklist

#### Documentation

- [x] Public **and** private symbols described?
- [x] Performance considerations for all subroutines?
  - [x] Time complexity?
  - [x] Memory complexity?
- [x] Examples for public interfaces?
  - [x] `cargo test --doc` passes?
- [x] `cargo doc --document-private-items` passes?

#### Testing

- [x] All post-conditions tested?
- [x] Dedicated tests for edge-cases?
- [x] Naming consistent with the existing codebase?
- [x] Organized into a module hierarchy?
- [x] `cargo test --tests` passes?
- [x] `MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo +nightly miri test` passes?
- [x] Reviewed coverage report via `cargo tarpaulin --fail-immediately --ignored --offline --line --out lcov --engine ptrace`?

#### Style

- [x] Considered [exception safety](https://doc.rust-lang.org/nomicon/exception-safety.html)?
- [x] `cargo check` passes?
- [x] `cargo clippy` passes?
- [x] `cargo fmt` passes?

#### Chores

- [x] Bumped version?
- [x] Link to new features in readme?
- [x] Rebased branch for clean commit history?
