### PR TITLE
test: reference returned from insert is mutable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "rust"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2024"
 
 authors = ["Tyler St. Onge <tyler@stonge.dev>"]

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -5254,6 +5254,18 @@ mod test {
             }
 
             #[test]
+            fn returned_reference_is_mutable() {
+                let expected = [0, 1, 2, 3, 4, 5];
+                let mut actual: Dynamic<_> = expected.iter().copied().collect();
+
+                let actual = actual.insert(2, 12345).expect("successful allocation");
+
+                *actual = 54321;
+
+                assert_eq!(actual, &mut 54321);
+            }
+
+            #[test]
             fn will_allocate_when_empty() {
                 let mut actual = Dynamic::<usize>::default();
 

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -3149,6 +3149,18 @@ mod test {
             }
 
             #[test]
+            fn returned_reference_is_mutable() {
+                let expected = [0, 1, 2, 3, 4, 5];
+                let mut actual: Doubly<_> = expected.iter().copied().collect();
+
+                let actual = actual.insert(2, 12345).expect("successful allocation");
+
+                *actual = 54321;
+
+                assert_eq!(actual, &mut 54321);
+            }
+
+            #[test]
             fn does_not_modify_leading_elements() {
                 const INDEX: usize = 2;
 

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -2831,6 +2831,18 @@ mod test {
             }
 
             #[test]
+            fn returned_reference_is_mutable() {
+                let expected = [0, 1, 2, 3, 4, 5];
+                let mut actual: Singly<_> = expected.iter().copied().collect();
+
+                let actual = actual.insert(2, 12345).expect("successful allocation");
+
+                *actual = 54321;
+
+                assert_eq!(actual, &mut 54321);
+            }
+
+            #[test]
             fn does_not_modify_leading_elements() {
                 const INDEX: usize = 2;
 


### PR DESCRIPTION
### Description

Closes #74 

### Checklist

#### Documentation

- [x] Public **and** private symbols described?
- [x] Performance considerations for all subroutines?
  - [x] Time complexity?
  - [x] Memory complexity?
- [x] Examples for public interfaces?
  - [x] `cargo test --doc` passes?
- [x] `cargo doc --document-private-items` passes?

#### Testing

- [x] All post-conditions tested?
- [x] Dedicated tests for edge-cases?
- [x] Naming consistent with the existing codebase?
- [x] Organized into a module hierarchy?
- [x] `cargo test --tests` passes?
- [x] `MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo +nightly miri test` passes?
- [x] Reviewed coverage report via `cargo tarpaulin --fail-immediately --ignored --offline --line --out lcov --engine ptrace`?

#### Style

- [x] Considered [exception safety](https://doc.rust-lang.org/nomicon/exception-safety.html)?
- [x] `cargo check` passes?
- [x] `cargo clippy` passes?
- [x] `cargo fmt` passes?

#### Chores

- [x] Bumped version?
- [x] Considered updating readme?
- [x] Rebased branch for clean commit history?
