### PR TITLE
test: returned inserted references are mutable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "rust"
-version = "0.15.2"
+version = "0.15.3"
 edition = "2024"
 
 authors = ["Tyler St. Onge <tyler@stonge.dev>"]

--- a/src/structure/collection/linear/array/dynamic.rs
+++ b/src/structure/collection/linear/array/dynamic.rs
@@ -6318,6 +6318,18 @@ mod test {
             }
 
             #[test]
+            fn returned_reference_is_mutable() {
+                let expected = [1, 2, 3, 4, 5];
+                let mut actual: Dynamic<_> = expected.iter().copied().collect();
+
+                let actual = actual.push(0).expect("successful allocation");
+
+                *actual = 12345;
+
+                assert_eq!(actual, &mut 12345);
+            }
+
+            #[test]
             fn does_not_modify_trailing_elements() {
                 let expected = [1, 2, 3, 4, 5];
                 let mut actual: Dynamic<_> = expected.iter().copied().collect();
@@ -6446,6 +6458,18 @@ mod test {
                 let actual = actual.push(5).expect("successful allocation");
 
                 assert_eq!(actual, &mut 5);
+            }
+
+            #[test]
+            fn returned_reference_is_mutable() {
+                let expected = [0, 1, 2, 3, 4];
+                let mut actual: Dynamic<_> = expected.iter().copied().collect();
+
+                let actual = actual.push(5).expect("successful allocation");
+
+                *actual = 12345;
+
+                assert_eq!(actual, &mut 12345);
             }
 
             #[test]

--- a/src/structure/collection/linear/list/doubly.rs
+++ b/src/structure/collection/linear/list/doubly.rs
@@ -3311,6 +3311,18 @@ mod test {
             }
 
             #[test]
+            fn returned_reference_is_mutable() {
+                let expected = [1, 2, 3, 4, 5];
+                let mut actual: Doubly<_> = expected.iter().copied().collect();
+
+                let actual = actual.prepend(0).expect("successful allocation");
+
+                *actual = 12345;
+
+                assert_eq!(actual, &mut 12345);
+            }
+
+            #[test]
             fn does_not_modify_trailing_elements() {
                 let expected = [1, 2, 3, 4, 5];
                 let mut actual: Doubly<_> = expected.iter().copied().collect();
@@ -3363,6 +3375,18 @@ mod test {
                 let actual = actual.append(5).expect("successful allocation");
 
                 assert_eq!(actual, &mut 5);
+            }
+
+            #[test]
+            fn returned_reference_is_mutable() {
+                let expected = [0, 1, 2, 3, 4];
+                let mut actual: Doubly<_> = expected.iter().copied().collect();
+
+                let actual = actual.append(5).expect("successful allocation");
+
+                *actual = 12345;
+
+                assert_eq!(actual, &mut 12345);
             }
 
             #[test]
@@ -4119,6 +4143,18 @@ mod test {
             }
 
             #[test]
+            fn returned_reference_is_mutable() {
+                let expected = [1, 2, 3, 4, 5];
+                let mut actual: Doubly<_> = expected.iter().copied().collect();
+
+                let actual = actual.push(0).expect("successful allocation");
+
+                *actual = 12345;
+
+                assert_eq!(actual, &mut 12345);
+            }
+
+            #[test]
             fn does_not_modify_trailing_elements() {
                 let expected = [1, 2, 3, 4, 5];
                 let mut actual: Doubly<_> = expected.iter().copied().collect();
@@ -4248,6 +4284,18 @@ mod test {
                 let actual = actual.push(5).expect("successful allocation");
 
                 assert_eq!(actual, &mut 5);
+            }
+
+            #[test]
+            fn returned_reference_is_mutable() {
+                let expected = [0, 1, 2, 3, 4];
+                let mut actual: Doubly<_> = expected.iter().copied().collect();
+
+                let actual = actual.push(5).expect("successful allocation");
+
+                *actual = 12345;
+
+                assert_eq!(actual, &mut 12345);
             }
 
             #[test]

--- a/src/structure/collection/linear/list/singly.rs
+++ b/src/structure/collection/linear/list/singly.rs
@@ -2990,6 +2990,18 @@ mod test {
             }
 
             #[test]
+            fn returned_reference_is_mutable() {
+                let expected = [1, 2, 3, 4, 5];
+                let mut actual: Singly<_> = expected.iter().copied().collect();
+
+                let actual = actual.prepend(0).expect("successful allocation");
+
+                *actual = 12345;
+
+                assert_eq!(actual, &mut 12345);
+            }
+
+            #[test]
             fn does_not_modify_trailing_elements() {
                 let expected = [1, 2, 3, 4, 5];
                 let mut actual: Singly<_> = expected.iter().copied().collect();
@@ -3041,6 +3053,18 @@ mod test {
                 let actual = actual.append(5).expect("successful allocation");
 
                 assert_eq!(actual, &mut 5);
+            }
+
+            #[test]
+            fn returned_reference_is_mutable() {
+                let expected = [0, 1, 2, 3, 4];
+                let mut actual: Singly<_> = expected.iter().copied().collect();
+
+                let actual = actual.append(5).expect("successful allocation");
+
+                *actual = 12345;
+
+                assert_eq!(actual, &mut 12345);
             }
 
             #[test]
@@ -3811,6 +3835,18 @@ mod test {
             }
 
             #[test]
+            fn returned_reference_is_mutable() {
+                let expected = [1, 2, 3, 4, 5];
+                let mut actual: Singly<_> = expected.iter().copied().collect();
+
+                let actual = actual.push(0).expect("successful allocation");
+
+                *actual = 12345;
+
+                assert_eq!(actual, &mut 12345);
+            }
+
+            #[test]
             fn does_not_modify_trailing_elements() {
                 let expected = [1, 2, 3, 4, 5];
                 let mut actual: Singly<_> = expected.iter().copied().collect();
@@ -3939,6 +3975,18 @@ mod test {
                 let actual = actual.push(5).expect("successful allocation");
 
                 assert_eq!(actual, &mut 5);
+            }
+
+            #[test]
+            fn returned_reference_is_mutable() {
+                let expected = [0, 1, 2, 3, 4];
+                let mut actual: Singly<_> = expected.iter().copied().collect();
+
+                let actual = actual.push(5).expect("successful allocation");
+
+                *actual = 12345;
+
+                assert_eq!(actual, &mut 12345);
             }
 
             #[test]


### PR DESCRIPTION
### Description

Closes #88 

### Checklist

#### Documentation

- [x] Public **and** private symbols described?
- [x] Performance considerations for all subroutines?
  - [x] Time complexity?
  - [x] Memory complexity?
- [x] Examples for public interfaces?
  - [x] `cargo test --doc` passes?
- [x] `cargo doc --document-private-items` passes?

#### Testing

- [x] All post-conditions tested?
- [x] Dedicated tests for edge-cases?
- [x] Naming consistent with the existing codebase?
- [x] Organized into a module hierarchy?
- [x] `cargo test --tests` passes?
- [x] `MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo +nightly miri test` passes?
- [x] Reviewed coverage report via `cargo tarpaulin --fail-immediately --ignored --offline --line --out lcov --engine ptrace`?

#### Style

- [x] Considered [exception safety](https://doc.rust-lang.org/nomicon/exception-safety.html)?
- [x] `cargo check` passes?
- [x] `cargo clippy` passes?
- [x] `cargo fmt` passes?

#### Chores

- [x] Bumped version?
- [x] Considered updating readme?
- [x] Rebased branch for clean commit history?
